### PR TITLE
In disable_table_options.rb, the behavior is different because the `super` is not called.

### DIFF
--- a/lib/ridgepole/ext/abstract_adapter/disable_table_options.rb
+++ b/lib/ridgepole/ext/abstract_adapter/disable_table_options.rb
@@ -36,6 +36,7 @@ module ActiveRecord
     class AbstractAdapter
       def self.inherited(subclass)
         subclass.prepend Ridgepole::Ext::AbstractAdapter::DisableTableOptions
+        super
       end
     end
   end


### PR DESCRIPTION
Since super was not called in the inherited method, ActiveSupport::DescendantsTracker's inherited was not called anymore and `ActiveRecord::ConnectionAdapters:: AbstractAdapter.descendants` was behaving incorrectly.

(Also, this is why the latest https://github.com/amatsuda/database_rewinder is not working anymore).

The steps to reproduce it are summarized in this repository.
https://github.com/pocari/mysql2-rails-DescendantsTracker

I have fixed it.