### PR TITLE
Omit test files from published gem package

### DIFF
--- a/ridgepole.gemspec
+++ b/ridgepole.gemspec
@@ -14,9 +14,12 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/ridgepole/ridgepole'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0")
+  spec.files = Dir.chdir(File.expand_path(__dir__)) do
+    `git ls-files -z`.split("\x0").reject do |f|
+      f.match(%r{\A(?:(?:test|spec|features)/|\.(?:git|travis|circleci)|appveyor)})
+    end
+  end
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
   spec.required_ruby_version = Gem::Requirement.new('>= 2.2.7') # rubocop:disable Gemspec/RequiredRubyVersion


### PR DESCRIPTION
This PR omits test files from the published gem package.

It reduces 35KB, about 50%, from the package that is built with `rake build` command.

```bash
$ du pkg/* --bytes 
29696	pkg/ridgepole-0.9.5.gem-after
65024	pkg/ridgepole-0.9.5.gem-before
```


The added code for `files` is the same as `bundle gem` command's default, which is https://github.com/rubygems/rubygems/blob/de0c8fb2b1f514135b5f35e6d6a259264f909edc/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt#L27-L31.

This PR also removes `test_files` option. Because the gem package contains files that are specified in `test_files`. And `test_files` option is no longer recommended. See https://github.com/rubygems/guides/issues/90 and https://github.com/rubygems/bundler/pull/3207.