### PR TITLE
Fix malformed error happened

### DIFF
--- a/lib/ridgepole/delta.rb
+++ b/lib/ridgepole/delta.rb
@@ -191,7 +191,7 @@ module Ridgepole
       errmsg = lines.with_index.map do |l, i|
         line_num = i + 1
         prefix = line_num == err_num ? '* ' : '  '
-        format("#{prefix}%<line_num>#{digit_number}d: ", line_num: line_num) + l
+        format("#{prefix}%<line_num>#{digit_number}d: %<line>s", line_num: line_num, line: l)
       end
 
       if err_num > 0

--- a/lib/ridgepole/delta.rb
+++ b/lib/ridgepole/delta.rb
@@ -191,7 +191,7 @@ module Ridgepole
       errmsg = lines.with_index.map do |l, i|
         line_num = i + 1
         prefix = line_num == err_num ? '* ' : '  '
-        format("#{prefix}%<line_num>#{digit_number}d: #{l}", line_num: line_num)
+        format("#{prefix}%<line_num>#{digit_number}d: ", line_num: line_num) + l
       end
 
       if err_num > 0


### PR DESCRIPTION
malformed format string error happened l of local variables in format method.

ex;
l = `t.column("consumption_tax_rate", :"integer", **{:default=>10, :null=>false, :comment=>"消費税率; 0: 0%\n 5: 5%\n  8: 8%\n 10: 10%"})`

`bundle exec ridgepole `

```
[ERROR] malformed format string - %\
        /home/vagrant/workspace/xxx/vendor/bundle/ruby/2.6.0/gems/ridgepole-0.9.5/lib/ridgepole/delta.rb:195:in `format'
```

I'm sorry for my bad English.
thanks.