### PR TITLE
--skip-drop-table by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ Usage: ridgepole [options]
         --dump-without-table-options
         --dump-with-default-fk-name
         --index-removed-drop-column
+        --drop-table
         --skip-drop-table
         --mysql-change-table-options
         --mysql-change-table-comment

--- a/bin/ridgepole
+++ b/bin/ridgepole
@@ -137,6 +137,7 @@ ARGV.options do |opt|
     opt.on('',   '--dump-without-table-options') { options[:dump_without_table_options] = true }
     opt.on('',   '--dump-with-default-fk-name') { options[:dump_with_default_fk_name] = true }
     opt.on('',   '--index-removed-drop-column') { options[:index_removed_drop_column] = true }
+    opt.on('',   '--drop-table') { options[:force_drop_table] = true }
     opt.on('',   '--skip-drop-table') { options[:skip_drop_table] = true }
     opt.on('',   '--mysql-change-table-options') { options[:mysql_change_table_options] = true }
     opt.on('',   '--mysql-change-table-comment') { options[:mysql_change_table_comment] = true }

--- a/lib/ridgepole/diff.rb
+++ b/lib/ridgepole/diff.rb
@@ -41,7 +41,7 @@ module Ridgepole
 
       scan_relation_info(relation_info)
 
-      unless @options[:merge] || @options[:skip_drop_table]
+      if !@options[:merge] && @options[:force_drop_table]
         from.each do |table_name, from_attrs|
           next unless target?(table_name)
 

--- a/spec/mysql/cli/ridgepole_spec.rb
+++ b/spec/mysql/cli/ridgepole_spec.rb
@@ -47,6 +47,7 @@ describe 'ridgepole' do
             --dump-without-table-options
             --dump-with-default-fk-name
             --index-removed-drop-column
+            --drop-table
             --skip-drop-table
             --mysql-change-table-options
             --mysql-change-table-comment

--- a/spec/mysql/comment/comment_spec.rb
+++ b/spec/mysql/comment/comment_spec.rb
@@ -166,7 +166,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
     end
 
     before { subject.diff(actual_dsl).migrate }
-    subject { client }
+    subject { client(force_drop_table: true) }
 
     it {
       delta = subject.diff('')

--- a/spec/mysql/fk/migrate_change_fk_spec.rb
+++ b/spec/mysql/fk/migrate_change_fk_spec.rb
@@ -211,7 +211,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
     end
 
     before { subject.diff(actual_dsl).migrate }
-    subject { client }
+    subject { client(force_drop_table: true) }
 
     it {
       delta = subject.diff(expected_dsl)
@@ -252,7 +252,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
     end
 
     before { subject.diff(actual_dsl).migrate }
-    subject { client }
+    subject { client(force_drop_table: true) }
 
     it {
       delta = subject.diff(expected_dsl)

--- a/spec/mysql/fk/migrate_drop_fk_spec.rb
+++ b/spec/mysql/fk/migrate_drop_fk_spec.rb
@@ -149,7 +149,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
     end
 
     before { subject.diff(dsl).migrate }
-    subject { client }
+    subject { client(force_drop_table: true) }
 
     it {
       delta = subject.diff('')
@@ -246,7 +246,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
     end
 
     before { subject.diff(dsl).migrate }
-    subject { client }
+    subject { client(force_drop_table: true) }
 
     it {
       delta = subject.diff('')
@@ -282,7 +282,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
     end
 
     before { subject.diff(actual_dsl).migrate }
-    subject { client }
+    subject { client(force_drop_table: true) }
 
     it {
       delta = subject.diff(expected_dsl)
@@ -318,7 +318,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
     end
 
     before { subject.diff(actual_dsl).migrate }
-    subject { client }
+    subject { client(force_drop_table: true) }
 
     it {
       delta = subject.diff(expected_dsl)

--- a/spec/mysql/migrate/migrate_drop_table_spec.rb
+++ b/spec/mysql/migrate/migrate_drop_table_spec.rb
@@ -110,7 +110,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
     end
 
     before { subject.diff(actual_dsl).migrate }
-    subject { client }
+    subject { client(force_drop_table: true) }
 
     it {
       delta = subject.diff(expected_dsl)

--- a/spec/mysql/migrate/migrate_skip_drop_table_spec.rb
+++ b/spec/mysql/migrate/migrate_skip_drop_table_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe 'Ridgepole::Client#diff -> migrate' do
-  context 'when skil drop table' do
+  context 'when skip drop table by default' do
     let(:actual_dsl) do
       erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|
@@ -131,7 +131,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
     end
 
     before { subject.diff(actual_dsl).migrate }
-    subject { client(skip_drop_table: true) }
+    subject { client }
 
     it {
       delta = subject.diff(expected_dsl.gsub(/create_table "clubs".+\n\s*t\..+\n\s*end/, ''))

--- a/spec/mysql/~default_name_fk/migrate_drop_fk_spec.rb
+++ b/spec/mysql/~default_name_fk/migrate_drop_fk_spec.rb
@@ -35,7 +35,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
     end
 
     before { subject.diff(actual_dsl).migrate }
-    subject { client(dump_with_default_fk_name: true) }
+    subject { client(dump_with_default_fk_name: true, force_drop_table: true) }
 
     it {
       delta = subject.diff(expected_dsl)
@@ -87,7 +87,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
     end
 
     before { subject.diff(dsl).migrate }
-    subject { client(dump_with_default_fk_name: true) }
+    subject { client(dump_with_default_fk_name: true, force_drop_table: true) }
 
     it {
       delta = subject.diff('')

--- a/spec/postgresql/fk/migrate_create_fk_spec.rb
+++ b/spec/postgresql/fk/migrate_create_fk_spec.rb
@@ -73,7 +73,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
       ERB
     end
 
-    before { client.diff('').migrate }
+    before { client(force_drop_table: true).diff('').migrate }
     subject { client }
 
     it {

--- a/spec/postgresql/fk/migrate_drop_fk_spec.rb
+++ b/spec/postgresql/fk/migrate_drop_fk_spec.rb
@@ -87,7 +87,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
     end
 
     before { subject.diff(dsl).migrate }
-    subject { client }
+    subject { client(force_drop_table: true) }
 
     it {
       delta = subject.diff('')
@@ -184,7 +184,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
     end
 
     before { subject.diff(dsl).migrate }
-    subject { client }
+    subject { client(force_drop_table: true) }
 
     it {
       delta = subject.diff('')

--- a/spec/postgresql/migrate/migrate_create_table_with_default_proc_spec.rb
+++ b/spec/postgresql/migrate/migrate_create_table_with_default_proc_spec.rb
@@ -17,7 +17,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
     let(:expected_dsl) { dsl }
 
     before { subject.diff(actual_dsl).migrate }
-    subject { client }
+    subject { client(force_drop_table: true) }
 
     it {
       expect(Ridgepole::Logger.instance).to_not receive(:warn)
@@ -42,7 +42,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
     end
 
     before { subject.diff(dsl).migrate }
-    subject { client }
+    subject { client(force_drop_table: true) }
 
     it {
       expect(Ridgepole::Logger.instance).to_not receive(:warn)

--- a/spec/postgresql/migrate/migrate_drop_table_spec.rb
+++ b/spec/postgresql/migrate/migrate_drop_table_spec.rb
@@ -109,7 +109,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
     end
 
     before { subject.diff(actual_dsl).migrate }
-    subject { client }
+    subject { client(force_drop_table: true) }
 
     it {
       delta = subject.diff(expected_dsl)

--- a/spec/postgresql/~default_name_fk/migrate_create_fk_spec.rb
+++ b/spec/postgresql/~default_name_fk/migrate_create_fk_spec.rb
@@ -73,7 +73,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
       ERB
     end
 
-    before { client.diff('').migrate }
+    before { client(force_drop_table: true).diff('').migrate }
     subject { client(dump_with_default_fk_name: true) }
 
     it {

--- a/spec/postgresql/~default_name_fk/migrate_drop_fk_spec.rb
+++ b/spec/postgresql/~default_name_fk/migrate_drop_fk_spec.rb
@@ -87,7 +87,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
     end
 
     before { subject.diff(dsl).migrate }
-    subject { client(dump_with_default_fk_name: true) }
+    subject { client(dump_with_default_fk_name: true, force_drop_table: true) }
 
     it {
       delta = subject.diff('')


### PR DESCRIPTION
Hi, I'd like to have `--skip-drop-table` option by default. For dropping, `--drop-table`.
#105 proposed about this, but looks not discussed.


For Data safety
--------------------

Obviously, resulting tail risk differs between default options.

* Missing `--skip-drop-table` causes permanent DATA LOST. 
* Missing `--drop-table` requires just rerun.


For Table Partitioning
--------------------

I tested Table Partitioning on PostgreSQL.  
With `--skip-drop-table` option, ridgepole works mostly well.

Table Partitioning has multiple tables called "partitions" that actual data resides.
Partitions schema derives from a single abstruct "partitioned table", so ridgepole doesn't have chance to migrate "partitions".

With `--skip-drop-table`, we can migrate "partitioned table" as just plain tables and then followed by its partitions.
(I don't mean that ridgepole can migrate a plain table into a partitioned table. It requires manual operations anyway.)
With partitioning, we have many arbitrary partitions, which faces DATA LOST risk with current ridgepole default behavior.


Table partitioning is just a case, and we will have situations that ridgepole should let several tables go.