### PR TITLE
Support activerecord v7.0.2

### DIFF
--- a/lib/ridgepole/diff.rb
+++ b/lib/ridgepole/diff.rb
@@ -422,9 +422,6 @@ module Ridgepole
             opts[:limit] = 4_294_967_295
           end
         end
-
-        # Workaround for Active Record 7.0
-        opts.delete(:precision) if attrs[:type] == :datetime && opts[:precision].nil?
       end
     end
 

--- a/lib/ridgepole/dumper.rb
+++ b/lib/ridgepole/dumper.rb
@@ -39,7 +39,7 @@ module Ridgepole
 
       dsl = stream.string.lines.select do |line|
         line !~ /\A#/ &&
-          line !~ /\AActiveRecord::Schema\.define/ &&
+          line !~ /\AActiveRecord::Schema(\[\d\.\d\])?\.define/ &&
           line !~ /\Aend/
       end
 

--- a/spec/mysql/bigint_pk/int_pk_spec.rb
+++ b/spec/mysql/bigint_pk/int_pk_spec.rb
@@ -3,14 +3,14 @@
 describe 'Ridgepole::Client (with integer pk)' do
   context 'when with id:integer' do
     let(:dsl) do
-      erbh(<<-ERB)
+      <<-RUBY
         create_table "books", id: :integer, force: :cascade do |t|
           t.string   "title", null: false
           t.integer  "author_id", null: false
-          t.datetime "created_at", <%= i cond(">= 7.0", { precision: 6 }) %>
-          t.datetime "updated_at", <%= i cond(">= 7.0", { precision: 6 }) %>
+          t.datetime "created_at"
+          t.datetime "updated_at"
         end
-      ERB
+      RUBY
     end
 
     subject { client }
@@ -25,14 +25,14 @@ describe 'Ridgepole::Client (with integer pk)' do
 
   context 'when without id:integer' do
     let(:dsl) do
-      erbh(<<-ERB)
+      <<-RUBY
         create_table "books", force: :cascade do |t|
           t.string   "title", null: false
           t.integer  "author_id", null: false
-          t.datetime "created_at", <%= i cond(">= 7.0", { precision: 6 }) %>
-          t.datetime "updated_at", <%= i cond(">= 7.0", { precision: 6 }) %>
+          t.datetime "created_at"
+          t.datetime "updated_at"
         end
-      ERB
+      RUBY
     end
 
     subject { client }

--- a/spec/mysql/default_lambda/default_lambda_spec.rb
+++ b/spec/mysql/default_lambda/default_lambda_spec.rb
@@ -14,11 +14,11 @@ describe 'Ridgepole::Client (use default:lambda)' do
       expect(delta.differ?).to be_truthy
       delta.migrate
 
-      expect(subject.dump).to match_fuzzy <<-RUBY
+      expect(subject.dump).to match_fuzzy erbh(<<-ERB)
         create_table "foos", force: :cascade do |t|
-          t.datetime "bar", default: -> { "CURRENT_TIMESTAMP" }, null: false
+          t.datetime "bar", <%= i cond(">= 7.0", { precision: nil }) %>, default: -> { "CURRENT_TIMESTAMP" }, null: false
         end
-      RUBY
+      ERB
     end
   end
 
@@ -66,7 +66,7 @@ describe 'Ridgepole::Client (use default:lambda)' do
 
       expect(subject.dump).to match_ruby erbh(<<-ERB)
         create_table "foos", force: :cascade do |t|
-          t.datetime "bar", default: "1970-01-01 00:00:00", null: false
+          t.datetime "bar", <%= i cond(">= 7.0", { precision: nil }) %>, default: "1970-01-01 00:00:00", null: false
         end
       ERB
     end
@@ -93,11 +93,11 @@ describe 'Ridgepole::Client (use default:lambda)' do
       expect(delta.differ?).to be_truthy
       delta.migrate
 
-      expect(subject.dump).to match_fuzzy <<-RUBY
+      expect(subject.dump).to match_fuzzy erbh(<<-ERB)
         create_table "foos", force: :cascade do |t|
-          t.datetime "bar", default: -> { "CURRENT_TIMESTAMP" }, null: false
+          t.datetime "bar", <%= i cond(">= 7.0", { precision: nil }) %>, default: -> { "CURRENT_TIMESTAMP" }, null: false
         end
-      RUBY
+      ERB
     end
   end
 
@@ -123,12 +123,12 @@ describe 'Ridgepole::Client (use default:lambda)' do
       expect(delta.differ?).to be_truthy
       delta.migrate
 
-      expect(subject.dump).to match_fuzzy <<-RUBY
+      expect(subject.dump).to match_fuzzy erbh(<<-ERB)
         create_table "foos", force: :cascade do |t|
-          t.datetime "bar", default: -> { "CURRENT_TIMESTAMP" }, null: false
+          t.datetime "bar", <%= i cond(">= 7.0", { precision: nil }) %>, default: -> { "CURRENT_TIMESTAMP" }, null: false
           t.integer "zoo"
         end
-      RUBY
+      ERB
     end
   end
 

--- a/spec/mysql/default_lambda/default_lambda_spec.rb
+++ b/spec/mysql/default_lambda/default_lambda_spec.rb
@@ -7,7 +7,7 @@ describe 'Ridgepole::Client (use default:lambda)' do
     it do
       delta = subject.diff(erbh(<<-ERB))
         create_table "foos", force: :cascade do |t|
-          t.datetime "bar", <%= i cond(">= 7.0", { precision: nil }) %>, default: -> { "CURRENT_TIMESTAMP" }, null: false
+          t.datetime "bar", default: -> { "CURRENT_TIMESTAMP<%= i cond(">= 7.0", "(6)") %>" }, null: false
         end
       ERB
 
@@ -16,7 +16,7 @@ describe 'Ridgepole::Client (use default:lambda)' do
 
       expect(subject.dump).to match_fuzzy erbh(<<-ERB)
         create_table "foos", force: :cascade do |t|
-          t.datetime "bar", <%= i cond(">= 7.0", { precision: nil }) %>, default: -> { "CURRENT_TIMESTAMP" }, null: false
+          t.datetime "bar", default: -> { "CURRENT_TIMESTAMP<%= i cond(">= 7.0", "(6)") %>" }, null: false
         end
       ERB
     end
@@ -26,7 +26,7 @@ describe 'Ridgepole::Client (use default:lambda)' do
     let(:dsl) do
       erbh(<<-ERB)
         create_table "foos", force: :cascade do |t|
-          t.datetime "bar", <%= i cond(">= 7.0", { precision: nil }) %>, default: -> { "CURRENT_TIMESTAMP" }, null: false
+          t.datetime "bar", default: -> { "CURRENT_TIMESTAMP<%= i cond(">= 7.0", "(6)") %>" }, null: false
         end
       ERB
     end
@@ -49,24 +49,24 @@ describe 'Ridgepole::Client (use default:lambda)' do
     before do
       subject.diff(erbh(<<-ERB)).migrate
         create_table "foos", force: :cascade do |t|
-          t.datetime "bar", <%= i cond(">= 7.0", { precision: nil }) %>, default: -> { "CURRENT_TIMESTAMP" }, null: false
+          t.datetime "bar", default: -> { "CURRENT_TIMESTAMP<%= i cond(">= 7.0", "(6)") %>" }, null: false
         end
       ERB
     end
 
     it do
-      delta = subject.diff(<<-RUBY)
+      delta = subject.diff(erbh(<<-ERB))
         create_table "foos", force: :cascade do |t|
-          t.datetime "bar", default: -> { '"1970-01-01 00:00:00"' }, null: false
+          t.datetime "bar", <%= i cond(">= 7.0", { precision: 6 }) %>, default: -> { '"1970-01-01 00:00:00"' }, null: false
         end
-      RUBY
+      ERB
 
       expect(delta.differ?).to be_truthy
       delta.migrate
 
       expect(subject.dump).to match_ruby erbh(<<-ERB)
         create_table "foos", force: :cascade do |t|
-          t.datetime "bar", <%= i cond(">= 7.0", { precision: nil }) %>, default: "1970-01-01 00:00:00", null: false
+          t.datetime "bar", default: "1970-01-01 00:00:00", null: false
         end
       ERB
     end
@@ -115,7 +115,7 @@ describe 'Ridgepole::Client (use default:lambda)' do
     it do
       delta = subject.diff(erbh(<<-ERB))
         create_table "foos", force: :cascade do |t|
-          t.datetime "bar", <%= i cond(">= 7.0", { precision: nil }) %>, default: -> { "CURRENT_TIMESTAMP" }, null: false
+          t.datetime "bar", default: -> { "CURRENT_TIMESTAMP<%= i cond(">= 7.0", "(6)") %>" }, null: false
           t.integer "zoo"
         end
       ERB
@@ -125,7 +125,7 @@ describe 'Ridgepole::Client (use default:lambda)' do
 
       expect(subject.dump).to match_fuzzy erbh(<<-ERB)
         create_table "foos", force: :cascade do |t|
-          t.datetime "bar", <%= i cond(">= 7.0", { precision: nil }) %>, default: -> { "CURRENT_TIMESTAMP" }, null: false
+          t.datetime "bar", default: -> { "CURRENT_TIMESTAMP<%= i cond(">= 7.0", "(6)") %>" }, null: false
           t.integer "zoo"
         end
       ERB
@@ -138,7 +138,7 @@ describe 'Ridgepole::Client (use default:lambda)' do
     before do
       subject.diff(erbh(<<-ERB)).migrate
         create_table "foos", force: :cascade do |t|
-          t.datetime "bar", <%= i cond(">= 7.0", { precision: nil }) %>, default: -> { "CURRENT_TIMESTAMP" }, null: false
+          t.datetime "bar", default: -> { "CURRENT_TIMESTAMP<%= i cond(">= 7.0", "(6)") %>" }, null: false
           t.integer "zoo"
         end
       ERB

--- a/spec/mysql/dump/dump_without_table_options_spec.rb
+++ b/spec/mysql/dump/dump_without_table_options_spec.rb
@@ -18,8 +18,8 @@ describe 'Ridgepole::Client#dump' do
         create_table "books", <%= i cond('>= 6.1', { id: { type: :bigint, unsigned: true } }, { id: :bigint, unsigned: true }) %>, force: :cascade, comment: "\\"london\\" bridge \\"is\\" falling \\"down\\"" do |t|
           t.string   "title", null: false
           t.integer  "author_id", null: false
-          t.datetime "created_at", <%= i cond(">= 7.0", { precision: 6 }) %>
-          t.datetime "updated_at", <%= i cond(">= 7.0", { precision: 6 }) %>
+          t.datetime "created_at"
+          t.datetime "updated_at"
         end
       ERB
     end

--- a/spec/mysql/fk/migrate_fk_with_column_spec.rb
+++ b/spec/mysql/fk/migrate_fk_with_column_spec.rb
@@ -7,16 +7,16 @@ describe 'Ridgepole::Client#diff -> migrate' do
         create_table "direct_messages", id: :integer, force: :cascade do |t|
           t.integer "sender_id"
           t.integer "reciever_id"
-          t.datetime "created_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
-          t.datetime "updated_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
+          t.datetime "created_at", null: false
+          t.datetime "updated_at", null: false
           t.index ["reciever_id"], name: "index_direct_messages_on_reciever_id"
           t.index ["sender_id"], name: "index_direct_messages_on_sender_id"
         end
 
         create_table "users", id: :integer, force: :cascade do |t|
           t.string "email"
-          t.datetime "created_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
-          t.datetime "updated_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
+          t.datetime "created_at", null: false
+          t.datetime "updated_at", null: false
         end
       ERB
     end
@@ -65,16 +65,16 @@ describe 'Ridgepole::Client#diff -> migrate' do
         create_table "direct_messages", id: :integer, force: :cascade do |t|
           t.integer "sender_id"
           t.integer "reciever_id"
-          t.datetime "created_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
-          t.datetime "updated_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
+          t.datetime "created_at", null: false
+          t.datetime "updated_at", null: false
           t.index ["reciever_id"], name: "index_direct_messages_on_reciever_id"
           t.index ["sender_id"], name: "index_direct_messages_on_sender_id"
         end
 
         create_table "users", id: :integer, force: :cascade do |t|
           t.string "email"
-          t.datetime "created_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
-          t.datetime "updated_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
+          t.datetime "created_at", null: false
+          t.datetime "updated_at", null: false
         end
       ERB
     end
@@ -109,16 +109,16 @@ describe 'Ridgepole::Client#diff -> migrate' do
         create_table "direct_messages", id: :integer, force: :cascade do |t|
           t.integer "sender_id"
           t.integer "reciever_id"
-          t.datetime "created_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
-          t.datetime "updated_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
+          t.datetime "created_at", null: false
+          t.datetime "updated_at", null: false
           t.index ["reciever_id"], name: "index_direct_messages_on_reciever_id"
           t.index ["sender_id"], name: "index_direct_messages_on_sender_id"
         end
 
         create_table "users", id: :integer, force: :cascade do |t|
           t.string "email"
-          t.datetime "created_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
-          t.datetime "updated_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
+          t.datetime "created_at", null: false
+          t.datetime "updated_at", null: false
         end
 
         add_foreign_key "direct_messages", "users", column: "reciever_id", on_delete: :cascade
@@ -131,16 +131,16 @@ describe 'Ridgepole::Client#diff -> migrate' do
         create_table "direct_messages", id: :integer, force: :cascade do |t|
           t.integer "sender_id"
           t.integer "reciever_id"
-          t.datetime "created_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
-          t.datetime "updated_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
+          t.datetime "created_at", null: false
+          t.datetime "updated_at", null: false
           t.index ["reciever_id"], name: "index_direct_messages_on_reciever_id"
           t.index ["sender_id"], name: "index_direct_messages_on_sender_id"
         end
 
         create_table "users", id: :integer, force: :cascade do |t|
           t.string "email"
-          t.datetime "created_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
-          t.datetime "updated_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
+          t.datetime "created_at", null: false
+          t.datetime "updated_at", null: false
         end
 
         add_foreign_key "direct_messages", "users", column: "reciever_id"

--- a/spec/mysql/migrate/migrate_change_column3_spec.rb
+++ b/spec/mysql/migrate/migrate_change_column3_spec.rb
@@ -3,17 +3,17 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when use timestamps (no change)' do
     let(:actual_dsl) do
-      erbh(<<-ERB)
+      <<-RUBY
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date     "birth_date", null: false
           t.string   "first_name", limit: 14, null: false
           t.string   "last_name", limit: 16, null: false
           t.string   "gender", limit: 1, null: false
           t.date     "hire_date", null: false
-          t.datetime "created_at", <%= i cond(">= 7.0", { precision: nil }) %>, null: false
-          t.datetime "updated_at", <%= i cond(">= 7.0", { precision: nil }) %>, null: false
+          t.datetime "created_at", null: false
+          t.datetime "updated_at", null: false
         end
-      ERB
+      RUBY
     end
 
     let(:expected_dsl) do
@@ -72,8 +72,8 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string   "last_name", limit: 16, null: false
           t.string   "gender", limit: 1, null: false
           t.date     "hire_date", null: false
-          t.datetime "created_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
-          t.datetime "updated_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
+          t.datetime "created_at", null: false
+          t.datetime "updated_at", null: false
         end
       ERB
     end

--- a/spec/mysql/migrate/migrate_change_column4_spec.rb
+++ b/spec/mysql/migrate/migrate_change_column4_spec.rb
@@ -18,18 +18,18 @@ describe 'Ridgepole::Client#diff -> migrate' do
     end
 
     let(:expected_dsl) do
-      erbh(<<-ERB)
+      <<-RUBY
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date     "birth_date", null: false
           t.string   "first_name", limit: 14, null: false
           t.string   "last_name", limit: 16, null: false
           t.string   "gender", limit: 1, null: false
           t.date     "hire_date", null: false
-          t.datetime "created_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
-          t.datetime "updated_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
+          t.datetime "created_at", null: false
+          t.datetime "updated_at", null: false
           t.boolean  "registered"
         end
-      ERB
+      RUBY
     end
 
     before { subject.diff(actual_dsl).migrate }
@@ -58,18 +58,18 @@ describe 'Ridgepole::Client#diff -> migrate' do
     end
 
     let(:expected_dsl) do
-      erbh(<<-ERB)
+      <<-RUBY
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date     "birth_date", null: false
           t.string   "first_name", limit: 14, null: false
           t.string   "last_name", limit: 16, null: false
           t.string   "gender", limit: 1, null: false
           t.date     "hire_date", null: false
-          t.datetime "created_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
-          t.datetime "updated_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
+          t.datetime "created_at", null: false
+          t.datetime "updated_at", null: false
           t.boolean  "registered", limit: 1
         end
-      ERB
+      RUBY
     end
 
     before { subject.diff(actual_dsl).migrate }

--- a/spec/mysql/migrate/migrate_change_column5_spec.rb
+++ b/spec/mysql/migrate/migrate_change_column5_spec.rb
@@ -10,8 +10,8 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string   "last_name", limit: 16, null: false
           t.string   "gender", limit: 1, null: false
           t.date     "hire_date", null: false
-          t.datetime "created_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
-          t.datetime "updated_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
+          t.datetime "created_at", null: false
+          t.datetime "updated_at", null: false
           t.binary   "registered_name"
         end
       ERB
@@ -25,8 +25,8 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string   "last_name", limit: 16, null: false
           t.string   "gender", limit: 1, null: false
           t.date     "hire_date", null: false
-          t.datetime "created_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
-          t.datetime "updated_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
+          t.datetime "created_at", null: false
+          t.datetime "updated_at", null: false
           t.binary   "registered_name", limit: 255
         end
       ERB
@@ -53,8 +53,8 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string   "last_name", limit: 16, null: false
           t.string   "gender", limit: 1, null: false
           t.date     "hire_date", null: false
-          t.datetime "created_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
-          t.datetime "updated_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
+          t.datetime "created_at", null: false
+          t.datetime "updated_at", null: false
           t.binary   "registered_name", limit: 255
         end
       ERB
@@ -68,8 +68,8 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string   "last_name", limit: 16, null: false
           t.string   "gender", limit: 1, null: false
           t.date     "hire_date", null: false
-          t.datetime "created_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
-          t.datetime "updated_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
+          t.datetime "created_at", null: false
+          t.datetime "updated_at", null: false
           t.binary   "registered_name"
         end
       ERB
@@ -104,18 +104,18 @@ describe 'Ridgepole::Client#diff -> migrate' do
     end
 
     let(:expected_dsl) do
-      erbh(<<-ERB)
+      <<-RUBY
         create_table "employees", primary_key: "emp_no", force: :cascade do |t|
           t.date     "birth_date", null: false
           t.string   "first_name", limit: 14, null: false
           t.string   "last_name", limit: 16, null: false
           t.string   "gender", limit: 1, null: false
           t.date     "hire_date", null: false
-          t.datetime "created_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
-          t.datetime "updated_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
+          t.datetime "created_at", null: false
+          t.datetime "updated_at", null: false
           t.binary   "registered_name"
         end
-      ERB
+      RUBY
     end
 
     before { subject.diff(actual_dsl).migrate }

--- a/spec/mysql/migrate/migrate_change_column6_spec.rb
+++ b/spec/mysql/migrate/migrate_change_column6_spec.rb
@@ -10,8 +10,8 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string   "last_name", limit: 16, null: false
           t.string   "gender", limit: 1, null: false
           t.date     "hire_date", null: false
-          t.datetime "created_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
-          t.datetime "updated_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
+          t.datetime "created_at", null: false
+          t.datetime "updated_at", null: false
           t.binary   "registered_name"
         end
       ERB
@@ -26,8 +26,8 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string   "last_name", limit: 16, null: false
           t.string   "gender", limit: 1, null: false
           t.date     "hire_date", null: false
-          t.datetime "created_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
-          t.datetime "updated_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
+          t.datetime "created_at", null: false
+          t.datetime "updated_at", null: false
           t.binary   "registered_name", limit: 255
         end
       ERB
@@ -70,8 +70,8 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string   "last_name", limit: 16, null: false
           t.string   "gender", limit: 1, null: false
           t.date     "hire_date", null: false
-          t.datetime "created_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
-          t.datetime "updated_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
+          t.datetime "created_at", null: false
+          t.datetime "updated_at", null: false
           t.binary   "registered_name"
         end
       ERB
@@ -86,8 +86,8 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string   "last_name", limit: 16, null: false
           t.string   "gender", limit: 1, null: false
           t.date     "hire_date", null: false
-          t.datetime "created_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
-          t.datetime "updated_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
+          t.datetime "created_at", null: false
+          t.datetime "updated_at", null: false
           t.binary   "registered_name", limit: 255
         end
       ERB
@@ -130,8 +130,8 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string   "last_name", limit: 16, null: false
           t.string   "gender", limit: 1, null: false
           t.date     "hire_date", null: false
-          t.datetime "created_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
-          t.datetime "updated_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
+          t.datetime "created_at", null: false
+          t.datetime "updated_at", null: false
           t.binary   "registered_name"
         end
       ERB
@@ -146,8 +146,8 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string   "last_name", limit: 16, null: false
           t.string   "gender", limit: 1, null: false
           t.date     "hire_date", null: false
-          t.datetime "created_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
-          t.datetime "updated_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
+          t.datetime "created_at", null: false
+          t.datetime "updated_at", null: false
           t.binary   "registered_name", limit: 255
         end
       ERB
@@ -188,8 +188,8 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string   "last_name", limit: 16, null: false
           t.string   "gender", limit: 1, null: false
           t.date     "hire_date", null: false
-          t.datetime "created_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
-          t.datetime "updated_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
+          t.datetime "created_at", null: false
+          t.datetime "updated_at", null: false
           t.binary   "registered_name"
         end
       ERB
@@ -204,8 +204,8 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.string   "last_name", limit: 16, null: false
           t.string   "gender", limit: 1, null: false
           t.date     "hire_date", null: false
-          t.datetime "created_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
-          t.datetime "updated_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
+          t.datetime "created_at", null: false
+          t.datetime "updated_at", null: false
           t.binary   "registered_name", limit: 255
         end
       ERB

--- a/spec/postgresql/migrate/migrate_add_expression_index_spec.rb
+++ b/spec/postgresql/migrate/migrate_add_expression_index_spec.rb
@@ -8,8 +8,8 @@ describe 'Ridgepole::Client#diff -> migrate' do
     let(:expected_dsl) { erbh(<<-ERB) }
       create_table "users", force: :cascade do |t|
         t.string "name", null: false
-        t.datetime "created_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
-        t.datetime "updated_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
+        t.datetime "created_at", null: false
+        t.datetime "updated_at", null: false
         t.index "lower((name)::text)", name: "index_users_on_lower_name"
       end
     ERB

--- a/spec/postgresql/migrate/migrate_create_table_with_default_proc_spec.rb
+++ b/spec/postgresql/migrate/migrate_create_table_with_default_proc_spec.rb
@@ -8,8 +8,8 @@ describe 'Ridgepole::Client#diff -> migrate' do
       erbh(<<-ERB)
         create_table "users", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
           t.string   "name"
-          t.datetime "created_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
-          t.datetime "updated_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
+          t.datetime "created_at", null: false
+          t.datetime "updated_at", null: false
         end
       ERB
     end
@@ -35,8 +35,8 @@ describe 'Ridgepole::Client#diff -> migrate' do
       erbh(<<-ERB)
         create_table "users", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
           t.string   "name"
-          t.datetime "created_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
-          t.datetime "updated_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
+          t.datetime "created_at", null: false
+          t.datetime "updated_at", null: false
         end
       ERB
     end
@@ -60,8 +60,8 @@ describe 'Ridgepole::Client#diff -> migrate' do
       erbh(<<-ERB)
         create_table "users", id: :uuid, default: -> { "uuid_generate_v1()" }, force: :cascade do |t|
           t.string   "name"
-          t.datetime "created_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
-          t.datetime "updated_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
+          t.datetime "created_at", null: false
+          t.datetime "updated_at", null: false
         end
       ERB
     end
@@ -70,8 +70,8 @@ describe 'Ridgepole::Client#diff -> migrate' do
       erbh(<<-ERB)
         create_table "users", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
           t.string   "name"
-          t.datetime "created_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
-          t.datetime "updated_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
+          t.datetime "created_at", null: false
+          t.datetime "updated_at", null: false
         end
       ERB
     end

--- a/spec/postgresql/migrate/migrate_drop_expression_index_spec.rb
+++ b/spec/postgresql/migrate/migrate_drop_expression_index_spec.rb
@@ -11,7 +11,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
     let(:actual_dsl) { erbh(<<-ERB) }
       create_table "users", force: :cascade do |t|
         t.string "name", null: false
-        t.datetime "created_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
+        t.datetime "created_at", null: false
         t.index "lower((name)::text)", name: "index_users_on_lower_name"
       end
     ERB

--- a/spec/postgresql/migrate/migrate_ext_cols_spec.rb
+++ b/spec/postgresql/migrate/migrate_ext_cols_spec.rb
@@ -3,25 +3,25 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   context 'when add column (ext cols)' do
     let(:actual_dsl) do
-      erbh(<<-ERB)
+      <<-RUBY
         create_table "items", force: :cascade do |t|
           t.string   "name"
           t.integer  "price"
           t.text     "description"
-          t.datetime "created_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
-          t.datetime "updated_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
+          t.datetime "created_at", null: false
+          t.datetime "updated_at", null: false
         end
-      ERB
+      RUBY
     end
 
     let(:expected_dsl) do
-      erbh(<<-ERB)
+      <<-RUBY
         create_table "items", force: :cascade do |t|
           t.string      "name"
           t.integer     "price"
           t.text        "description"
-          t.datetime    "created_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
-          t.datetime    "updated_at", <%= i cond(">= 7.0", { precision: 6 }) %>, null: false
+          t.datetime    "created_at", null: false
+          t.datetime    "updated_at", null: false
           t.daterange   "daterange"
           t.numrange    "numrange"
           t.tsrange     "tsrange"
@@ -47,7 +47,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.bit_varying "bit varying"
           t.money       "money", scale: 2
         end
-      ERB
+      RUBY
     end
 
     before { subject.diff(actual_dsl).migrate }


### PR DESCRIPTION
close https://github.com/ridgepole/ridgepole/issues/379

According to [CHANGELOG](https://github.com/rails/rails/blob/7-0-stable/activerecord/CHANGELOG.md#rails-702-february-08-2022), activerecord v7.0.2 includes the following related changes.

> *   Dump the precision for datetime columns following the new defaults.

> *   Dump the database schema containing the current Rails version.
> 
>     Since #42297, Rails now generate datetime columns
>     with a default precision of 6. This means that users upgrading to Rails 7.0 from 6.1,
>     when loading the database schema, would get the new precision value, which would not match
>     the production schema.
> 
>     To avoid this the schema dumper will generate the new format which will include the Rails
>     version and will look like this:
> 
>     ```
>     ActiveRecord::Schema[7.0].define
>     ```

This PR deals with these changes by:

- update the regexp in `Ridgepole::Dumper#dump` to handle the new format of schema dump.
- remove the workaround for activerecord v7.0 in `Ridgepole::Diff#normalize_column_options!` and fix tests since the precision option for datetime columns follows the new defaults.
