### PR TITLE
Add README and tests of generated column

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,8 @@ See `mysql> show character set;` to find charset / collation pair for your syste
 
 ## Generated Column (MySQL)
 
-There should be NO extra white spaces in the expression (such as after comma).
+There should be NO extra white spaces in the expression (such as after comma).  
+Quotes in expression may cause the operations failure with MySQL 8.0.
 
 ```ruby
 create_table "users", force: :cascade do |t|

--- a/README.md
+++ b/README.md
@@ -212,6 +212,18 @@ activerecord 5.0.0 and activerecord-mysql-awesome dumps a collation rather than 
 
 See `mysql> show character set;` to find charset / collation pair for your system.
 
+## Generated Column (MySQL)
+
+There should be NO extra white spaces in the expression (such as after comma).
+
+```ruby
+create_table "users", force: :cascade do |t|
+  t.string   "last_name"
+  t.string   "first_name"
+  t.virtual  "full_name", type: :string, as: "concat(`last_name`,' ',`first_name`)", stored: true
+end
+```
+
 ## Execute
 ```ruby
 create_table "authors", force: :cascade do |t|

--- a/lib/ridgepole/diff.rb
+++ b/lib/ridgepole/diff.rb
@@ -506,6 +506,14 @@ module Ridgepole
         attrs2.fetch(:options).delete(:comment)
       end
 
+      if attrs1[:options][:as] != attrs2[:options][:as] && attrs1[:options].fetch(:as, '').delete(' ') == attrs2[:options].fetch(:as, '').delete(' ')
+        @logger.warn(<<-MSG)
+[WARNING] Same expressions but only differed by white spaces were detected. This operation may fail.
+  Before: '#{attrs1[:options][:as]}'
+  After : '#{attrs2[:options][:as]}'
+        MSG
+      end
+
       attrs1 == attrs2
     end
 

--- a/spec/mysql/virtual/add_virtual_column_spec.rb
+++ b/spec/mysql/virtual/add_virtual_column_spec.rb
@@ -35,7 +35,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
       expect(subject.dump).to match_ruby expected_dsl
     }
 
-    context 'when generated column has extra white spaces' do
+    context 'when generated column has extra white spaces', condition: %i[mysql57] do
       let(:expected_dsl) do
         <<-RUBY
         create_table "books", force: :cascade do |t|

--- a/spec/mysql/virtual/add_virtual_column_spec.rb
+++ b/spec/mysql/virtual/add_virtual_column_spec.rb
@@ -35,7 +35,40 @@ describe 'Ridgepole::Client#diff -> migrate' do
       expect(subject.dump).to match_ruby expected_dsl
     }
 
-    context 'when generated column has extra white spaces', condition: %i[mysql57] do
+    context 'when generated column has single quotes' do
+      let(:expected_dsl) do
+        <<-RUBY
+        create_table "books", force: :cascade do |t|
+          t.string   "title"
+          t.virtual  "sale_title", type: :string, as: "concat('[SALE]',`title`)"
+          t.index ["title"], name: "index_books_on_title"
+        end
+        RUBY
+      end
+      let(:delta) { subject.diff(expected_dsl) }
+      it {
+        expect(delta.differ?).to be_truthy
+        expect(subject.dump).to match_ruby actual_dsl
+        expect { delta.migrate }.not_to raise_error
+        if SpecCondition.mysql80?
+          expect(subject.dump).not_to match_ruby expected_dsl # FIXME?
+        else
+          expect(subject.dump).to match_ruby expected_dsl
+        end
+      }
+      context 'migrated again without change' do
+        before { subject.diff(expected_dsl).migrate }
+        it {
+          if SpecCondition.mysql80?
+            expect { delta.migrate }.to raise_error(RuntimeError) # FIXME?
+          else
+            expect { delta.migrate }.not_to raise_error
+          end
+        }
+      end
+    end
+
+    context 'when generated column has extra white spaces', condition: %i[mysql57] do # FIXME?: add mysql80
       let(:expected_dsl) do
         <<-RUBY
         create_table "books", force: :cascade do |t|


### PR DESCRIPTION
I tried to use generated columns and found that white spaces( ) and quotes(') in expressions may cause buggy behaviors.

## 1. White space issues with MySQL5.7 and MySQL8.0

For example, `as: "concat('[SALE]', `title`)"` has white space between two arguments. The first migration goes fine but after that, ridgepole thinks there is always diffs and try to migrate (and fails). It works fine all the time without extra white spaces.

## 2. Single quote issues with MySQL8.0

The example expression above contains single quotes. It makes ridgepole thinks there is always diff if MySQL8.0. First migration goes fine, but following migrations fail.

## What I did

- Added usage with cautions on README
- Added tests to describe current behavior
- Tells developers explicitly why migration failed by warning (not works with MySQL8)

## What I didn't

- Fixing quotes problem and warning with MySQL8.0
- Validating SQL before first migration (due to backward compatibility)

By any chance, is it because of these behaviors, there is still no usage on README about generated columns? If then, please feel free to close this PR :)