### PR TITLE
Support check constraint for PostgreSQL

### DIFF
--- a/lib/ridgepole/dsl_parser/context.rb
+++ b/lib/ridgepole/dsl_parser/context.rb
@@ -91,6 +91,21 @@ module Ridgepole
         }
       end
 
+      def add_check_constraint(table_name, expression, options = {})
+        table_name = table_name.to_s
+        expression = expression.to_s
+        options[:name] = options[:name].to_s if options[:name]
+
+        idx = options[:name] || expression
+
+        @__definition[table_name] ||= {}
+        @__definition[table_name][:check_constraints] ||= {}
+        @__definition[table_name][:check_constraints][idx] = {
+          expression: expression,
+          options: options,
+        }
+      end
+
       def require(file)
         schemafile = %r{\A/}.match?(file) ? file : File.join(@__working_dir, file)
 

--- a/lib/ridgepole/dsl_parser/table_definition.rb
+++ b/lib/ridgepole/dsl_parser/table_definition.rb
@@ -159,6 +159,10 @@ module Ridgepole
         end
       end
       alias belongs_to references
+
+      def check_constraint(expression, options = {})
+        @base.add_check_constraint(@table_name, expression, options)
+      end
     end
   end
 end

--- a/spec/postgresql/migrate/migrate_add_check_constraint_spec.rb
+++ b/spec/postgresql/migrate/migrate_add_check_constraint_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+describe 'Ridgepole::Client#diff -> migrate' do
+  context 'when add check constraint' do
+    let(:actual_dsl) do
+      erbh(<<-ERB)
+        create_table "clubs", force: :cascade do |t|
+          t.bigint "value", null: false
+        end
+      ERB
+    end
+
+    let(:expected_dsl) do
+      erbh(<<-ERB)
+        create_table "clubs", force: :cascade do |t|
+          t.bigint "value", null: false
+          t.check_constraint "value > 100", name: "value_check"
+        end
+      ERB
+    end
+
+    before { subject.diff(actual_dsl).migrate }
+    subject { client }
+
+    it {
+      delta = subject.diff(expected_dsl)
+      expect(delta.differ?).to be_truthy
+      expect(subject.dump).to match_ruby actual_dsl
+      delta.migrate
+      expect(subject.dump).to match_ruby expected_dsl
+    }
+  end
+end

--- a/spec/postgresql/migrate/migrate_change_check_constraint_spec.rb
+++ b/spec/postgresql/migrate/migrate_change_check_constraint_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+describe 'Ridgepole::Client#diff -> migrate' do
+  context 'when change check constraint' do
+    let(:actual_dsl) do
+      erbh(<<-ERB)
+        create_table "clubs", force: :cascade do |t|
+          t.bigint "value", null: false
+          t.check_constraint "value > 0", name: "value_check"
+        end
+      ERB
+    end
+
+    let(:expected_dsl) do
+      erbh(<<-ERB)
+        create_table "clubs", force: :cascade do |t|
+          t.bigint "value", null: false
+          t.check_constraint "value > 100", name: "value_check"
+        end
+      ERB
+    end
+
+    before { subject.diff(actual_dsl).migrate }
+    subject { client }
+
+    it {
+      delta = subject.diff(expected_dsl)
+      expect(delta.differ?).to be_truthy
+      expect(subject.dump).to match_ruby actual_dsl
+      delta.migrate
+      expect(subject.dump).to match_ruby expected_dsl
+    }
+  end
+end

--- a/spec/postgresql/migrate/migrate_drop_check_constraint_spec.rb
+++ b/spec/postgresql/migrate/migrate_drop_check_constraint_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+describe 'Ridgepole::Client#diff -> migrate' do
+  context 'when drop check constraint' do
+    let(:actual_dsl) do
+      erbh(<<-ERB)
+        create_table "clubs", force: :cascade do |t|
+          t.bigint "value", null: false
+          t.check_constraint "value > 100", name: "value_check"
+        end
+      ERB
+    end
+
+    let(:expected_dsl) do
+      erbh(<<-ERB)
+        create_table "clubs", force: :cascade do |t|
+          t.bigint "value", null: false
+        end
+      ERB
+    end
+
+    before { subject.diff(actual_dsl).migrate }
+    subject { client }
+
+    it {
+      delta = subject.diff(expected_dsl)
+      expect(delta.differ?).to be_truthy
+      expect(subject.dump).to match_ruby actual_dsl
+      delta.migrate
+      expect(subject.dump).to match_ruby expected_dsl
+    }
+  end
+end


### PR DESCRIPTION
Currently, if you try to use check constraints in ridgepole, you will get an undefined method error.

```Schemafile
create_table "offices", force: :cascade do |t|
  t.integer :price
  t.check_constraint "price > 100", name: 'check_price'
end
```

```sh
$ ./bin/ridgepole --config config/database.yml --apply
[ERROR] undefined method `check_constraint' for #<Ridgepole::DSLParser::TableDefinition...
```

This PR fixes the error by adding `add_check_constraint` and `t.check_constraint` to ridgepole.

## NOTE

At least it works now, but there are some things I didn't know how to implement.

- `check_constraint` is not supported in versions below 6.1. How should I skip the test?
- The `@options[:merge]` test is in a directory under `spec/mysql`. Should I implement this for check constraint that are only used in PostgreSQL like this one?
- In normal operation, check constraint is executed in two separate queries to avoid table locking. How to reproduce this way by ridgepole?
  1.`add_check_constraint('items', 'price > 0', name: 'xxx', validate: false)` The validate option allows the check constraint to run asynchronously without locking. This check constraint is marked as `valid = false`. 2.
  2.`validate_check_constraint('items', name: 'xxx')` Wait for the asynchronous check constraint validation to complete. If validation succeeds, it is marked with `valid = true`. This validation does not lock the table.
- 