### PR TITLE
Remove MySQL 5.6 tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,6 @@ jobs:
           - "3.0.4"
           - "3.1.2"
         env:
-          - MYSQL56=1
           - MYSQL57=1
           - MYSQL80=1
           - POSTGRESQL=1
@@ -43,11 +42,9 @@ jobs:
         run: |
           for i in {1..60}; do docker-compose up -d && break; sleep 1; done
           # Wait until database servers start
-          function mysql_ping { mysqladmin -u root -h 127.0.0.1 -P 13316 ping; }
-          function mysql57_ping { mysqladmin -u root -h 127.0.0.1 -P 13317 ping; }
+          function mysql57_ping { mysqladmin -u root -h 127.0.0.1 -P 13316 ping; }
           function mysql80_ping { mysqladmin -u root -h 127.0.0.1 -P 13318 ping; }
           function pg_ping { PGPASSWORD=password pg_isready -U postgres -h 127.0.0.1 -p 15442; }
-          for i in {1..60}; do mysql_ping && break; sleep 1; done
           for i in {1..60}; do mysql57_ping && break; sleep 1; done
           for i in {1..60}; do mysql80_ping && break; sleep 1; done
           for i in {1..60}; do pg_ping && break; sleep 1; done

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ AllCops:
     - "gemfiles/**/*"
     - "omnibus-ridgepole/**/*"
     - "vendor/bundle/**/*"
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.7
   NewCops: enable
 Bundler/OrderedGems:
   Include:

--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ bundle install
 bundle exec appraisal install
 bundle exec appraisal activerecord-7.0 rake
 # POSTGRESQL=1 bundle exec appraisal activerecord-7.0 rake
-# MYSQL57=1 bundle exec appraisal activerecord-7.0 rake
+# MYSQL80=1 bundle exec appraisal activerecord-7.0 rake
 ```
 
 **Notice:** Ruby 2.6 or above/mysql-client/postgresql-client is required.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,19 +1,14 @@
 version: "3.8"
 services:
-  mysql:
-    image: "mysql:5.6.51"
+  mysql57:
+    image: "mysql:5.7"
+    platform: linux/amd64
     ports:
       - "13316:3306"
     environment:
       MYSQL_ROOT_PASSWORD: password
-  mysql57:
-    image: "mysql:5.7.39"
-    ports:
-      - "13317:3306"
-    environment:
-      MYSQL_ROOT_PASSWORD: password
   mysql80:
-    image: "mysql:8.0.30"
+    image: "mysql:8.0"
     ports:
       - "13318:3306"
     environment:

--- a/lib/ridgepole/cli/config.rb
+++ b/lib/ridgepole/cli/config.rb
@@ -66,7 +66,7 @@ module Ridgepole
 
         query_hash =
           if uri.query
-            uri.query.split('&').map { |pair| pair.split('=') }.to_h
+            uri.query.split('&').to_h { |pair| pair.split('=') }
           else
             {}
           end

--- a/ridgepole.gemspec
+++ b/ridgepole.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.2.7') # rubocop:disable Gemspec/RequiredRubyVersion
+  spec.required_ruby_version = Gem::Requirement.new('>= 2.7')
 
   spec.add_dependency 'activerecord', '>= 5.1', '< 7.1'
   spec.add_dependency 'diffy'

--- a/spec/mysql/json/add_json_column_spec.rb
+++ b/spec/mysql/json/add_json_column_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe 'Ridgepole::Client#diff -> migrate' do
-  context 'when add virtual column', condition: %i[mysql57 mysql80] do
+  context 'when add virtual column' do
     let(:actual_dsl) do
       erbh(<<-ERB)
         create_table "books", force: :cascade do |t|

--- a/spec/mysql/json/change_json_column_spec.rb
+++ b/spec/mysql/json/change_json_column_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe 'Ridgepole::Client#diff -> migrate' do
-  context 'when change virtual column / not null -> null', condition: %i[mysql57 mysql80] do
+  context 'when change virtual column / not null -> null' do
     let(:actual_dsl) do
       erbh(<<-ERB)
         create_table "books", force: :cascade do |t|
@@ -34,7 +34,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
     }
   end
 
-  context 'when change virtual column / json -> string', condition: %i[mysql57 mysql80] do
+  context 'when change virtual column / json -> string', condition: %i[mysql80] do
     let(:actual_dsl) do
       erbh(<<-ERB)
         create_table "books", force: :cascade do |t|
@@ -67,7 +67,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
     }
   end
 
-  context 'when change virtual column / string -> json', condition: %i[mysql57 mysql80] do
+  context 'when change virtual column / string -> json' do
     let(:actual_dsl) do
       erbh(<<-ERB)
         create_table "books", force: :cascade do |t|

--- a/spec/mysql/json/drop_json_column_spec.rb
+++ b/spec/mysql/json/drop_json_column_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe 'Ridgepole::Client#diff -> migrate' do
-  context 'when add virtual column', condition: %i[mysql57 mysql80] do
+  context 'when add virtual column' do
     let(:actual_dsl) do
       erbh(<<-ERB)
         create_table "books", force: :cascade do |t|

--- a/spec/mysql/virtual/add_virtual_column_spec.rb
+++ b/spec/mysql/virtual/add_virtual_column_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe 'Ridgepole::Client#diff -> migrate' do
-  context 'when add virtual column', condition: %i[mysql57 mysql80] do
+  context 'when add virtual column' do
     let(:actual_dsl) do
       <<-RUBY
         create_table "books", force: :cascade do |t|

--- a/spec/mysql/virtual/change_virtual_column_spec.rb
+++ b/spec/mysql/virtual/change_virtual_column_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe 'Ridgepole::Client#diff -> migrate' do
-  context 'when change virtual column', condition: %i[mysql57 mysql80] do
+  context 'when change virtual column' do
     let(:actual_dsl) do
       <<-RUBY
         create_table "books", force: :cascade do |t|

--- a/spec/mysql/virtual/drop_virtual_column_spec.rb
+++ b/spec/mysql/virtual/drop_virtual_column_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe 'Ridgepole::Client#diff -> migrate' do
-  context 'when drop virtual column', condition: %i[mysql57 mysql80] do
+  context 'when drop virtual column' do
     let(:actual_dsl) do
       <<-RUBY
         create_table "books", force: :cascade do |t|

--- a/spec/spec_condition.rb
+++ b/spec/spec_condition.rb
@@ -9,7 +9,7 @@ module SpecCondition
     end
 
     def mysql57?
-      ENV['MYSQL57'] == '1'
+      !postgresql? && !mysql80?
     end
 
     def mysql80?

--- a/spec/spec_const.rb
+++ b/spec/spec_const.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 TEST_MYSQL_HOST = ENV['DOCKER_HOST'] ? ENV['DOCKER_HOST'].gsub(%r{\Atcp://|:\d+\z}, '') : '127.0.0.1'
-TEST_MYSQL_PORT = if ENV['MYSQL57'] == '1'
-                    13317 # rubocop:disable Style/NumericLiterals
-                  elsif ENV['MYSQL80'] == '1'
+TEST_MYSQL_PORT = if ENV['MYSQL80'] == '1'
                     13318 # rubocop:disable Style/NumericLiterals
                   else
                     13316 # rubocop:disable Style/NumericLiterals


### PR DESCRIPTION
MySQL 5.6 is over a year past EoL so I'm removing the tests.
cf. https://endoflife.date/mysql

Also, the supported Ruby version is 2.7 or higher.