### PR TITLE
Drop older rails

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,6 @@ jobs:
           - MYSQL80=1
           - POSTGRESQL=1
         gemfile:
-          - gemfiles/activerecord_6.0.gemfile
           - gemfiles/activerecord_6.1.gemfile
           - gemfiles/activerecord_7.0.gemfile
     env:

--- a/Appraisals
+++ b/Appraisals
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-appraise 'activerecord-6.0' do
-  gem 'activerecord', '~> 6.0.6'
-end
-
 appraise 'activerecord-6.1' do
   gem 'activerecord', '~> 6.1.7'
 end

--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ end
 ```
 
 ```sh
-$ ridgepole -a -c database.yml --check-relation-type bigint # default primary key type (e.g. `<5.1`: integer, `>=5.1`: bigint for MySQL)
+$ ridgepole -a -c database.yml --check-relation-type bigint # default primary key type (e.g. bigint for MySQL)
 Apply `Schemafile`
 ...
 [WARNING] Relation column type is different.

--- a/gemfiles/activerecord_7.0.gemfile
+++ b/gemfiles/activerecord_7.0.gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "~> 7.0.4"
+gem "activerecord", "~> 7.0.7"
 
 gemspec path: "../"

--- a/lib/ridgepole/delta.rb
+++ b/lib/ridgepole/delta.rb
@@ -299,7 +299,7 @@ execute "ALTER TABLE #{ActiveRecord::Base.connection.quote_table_name(table_name
     end
 
     def append_change_table_raw_options(table_name, raw_table_options, table_charset, table_collation, buf)
-      if raw_table_options.blank? && ActiveRecord.gem_version >= Gem::Version.new('6.1.0')
+      if raw_table_options.blank?
         # Implicit engine is InnoDB in 6.1.0
         # related: https://github.com/rails/rails/pull/39365/files#diff-868f1dccfcbed26a288bf9f3fd8a39c863a4413ab0075e12b6805d9798f556d1R441
         raw_table_options = +'ENGINE=InnoDB'

--- a/lib/ridgepole/ext/abstract_adapter/disable_table_options.rb
+++ b/lib/ridgepole/ext/abstract_adapter/disable_table_options.rb
@@ -18,8 +18,6 @@ module Ridgepole
 
           if options && @__without_table_options
             options.delete(:options)
-
-            # For >= AR 6.1.0
             options.delete(:charset)
             options.delete(:collation)
           end

--- a/lib/ridgepole/external_sql_executer.rb
+++ b/lib/ridgepole/external_sql_executer.rb
@@ -8,7 +8,7 @@ module Ridgepole
     end
 
     def execute(sql)
-      cmd = Shellwords.join([@script, sql, JSON.dump(connection_configuration_hash)])
+      cmd = Shellwords.join([@script, sql, JSON.dump(ActiveRecord::Base.connection_db_config.configuration_hash)])
       @logger.info("Execute #{@script}")
       script_basename = File.basename(@script)
 
@@ -44,17 +44,6 @@ module Ridgepole
         end
 
         raise "`#{@script}` execution failed" unless wait_thr.value.success?
-      end
-    end
-
-    private
-
-    def connection_configuration_hash
-      if ActiveRecord.gem_version < Gem::Version.new('6.1.0')
-        # NOTE: Remove code when stopping support for versions below 6.1
-        ActiveRecord::Base.connection_config
-      else
-        ActiveRecord::Base.connection_db_config.configuration_hash
       end
     end
   end

--- a/ridgepole.gemspec
+++ b/ridgepole.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = Gem::Requirement.new('>= 2.7')
 
-  spec.add_dependency 'activerecord', '>= 5.1', '< 7.1'
+  spec.add_dependency 'activerecord', '>= 6.1', '< 7.1'
   spec.add_dependency 'diffy'
 
   spec.add_development_dependency 'appraisal', '>= 2.2.0'

--- a/spec/mysql/_migrate/migrate_change_table_option_spec.rb
+++ b/spec/mysql/_migrate/migrate_change_table_option_spec.rb
@@ -4,7 +4,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
   context 'when change mysql table options' do
     let(:actual_dsl) do
       erbh(<<-ERB, utf8: condition(:mysql80) ? 'utf8mb3' : 'utf8')
-        create_table "employees", primary_key: "emp_no", force: :cascade, <%= i cond(">= 6.1", { charset: @utf8, options: "ENGINE=MyISAM" }, { options: "ENGINE=MyISAM DEFAULT CHARSET=\#{@utf8}" }) %> do |t|
+        create_table "employees", primary_key: "emp_no", force: :cascade, charset: "<%= @utf8 %>", options: "ENGINE=MyISAM"  do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false
           t.string "last_name", limit: 16, null: false
@@ -16,7 +16,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
     let(:expected_dsl) do
       erbh(<<-ERB)
-        create_table "employees", primary_key: "emp_no", force: :cascade, <%= i cond(">= 6.1", { charset: "ascii" }, { options: "ENGINE=InnoDB DEFAULT CHARSET=ascii" }) %> do |t|
+        create_table "employees", primary_key: "emp_no", force: :cascade, charset: "ascii"  do |t|
           t.date   "birth_date", null: false
           t.string "first_name", limit: 14, null: false, collation: "utf8_general_ci"
           t.string "last_name", limit: 16, null: false, collation: "utf8_general_ci"

--- a/spec/mysql/collation/collation_spec.rb
+++ b/spec/mysql/collation/collation_spec.rb
@@ -4,7 +4,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
   context 'when change column (add collation)' do
     let(:actual_dsl) do
       erbh(<<-ERB)
-        create_table "employee_clubs", <%= i cond("< 6.1", { id: :bigint, unsigned: true }, { id: { type: :bigint, unsigned: true } }) %>, force: :cascade do |t|
+        create_table "employee_clubs", id: { type: :bigint, unsigned: true }, force: :cascade do |t|
           t.integer "emp_no", null: false
           t.integer "club_id", null: false, unsigned: true
           t.string  "string", null: false, collation: "ascii_bin"
@@ -15,7 +15,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
     let(:expected_dsl) do
       erbh(<<-ERB)
-        create_table "employee_clubs", <%= i cond("< 6.1", { id: :bigint, unsigned: true }, { id: { type: :bigint, unsigned: true } }) %>, force: :cascade do |t|
+        create_table "employee_clubs", id: { type: :bigint, unsigned: true }, force: :cascade do |t|
           t.integer "emp_no", null: false
           t.integer "club_id", null: false, unsigned: true
           t.string  "string", null: false, collation: "ascii_bin"
@@ -39,7 +39,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
   context 'when change column (delete collation)' do
     let(:actual_dsl) do
       erbh(<<-ERB)
-        create_table "employee_clubs", <%= i cond("< 6.1", { id: :bigint, unsigned: true }, { id: { type: :bigint, unsigned: true } }) %>, force: :cascade do |t|
+        create_table "employee_clubs", id: { type: :bigint, unsigned: true }, force: :cascade do |t|
           t.integer "emp_no", null: false
           t.integer "club_id", null: false, unsigned: true
           t.string  "string", null: false, collation: "ascii_bin"
@@ -50,7 +50,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
     let(:expected_dsl) do
       erbh(<<-ERB)
-        create_table "employee_clubs", <%= i cond("< 6.1", { id: :bigint, unsigned: true }, { id: { type: :bigint, unsigned: true } }) %>, force: :cascade do |t|
+        create_table "employee_clubs", id: { type: :bigint, unsigned: true }, force: :cascade do |t|
           t.integer "emp_no", null: false
           t.integer "club_id", null: false, unsigned: true
           t.string  "string", null: false, collation: "ascii_bin"
@@ -74,7 +74,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
   context 'when change column (change collation)' do
     let(:actual_dsl) do
       erbh(<<-ERB)
-        create_table "employee_clubs", <%= i cond("< 6.1", { id: :bigint, unsigned: true }, { id: { type: :bigint, unsigned: true } }) %>, force: :cascade do |t|
+        create_table "employee_clubs", id: { type: :bigint, unsigned: true }, force: :cascade do |t|
           t.integer "emp_no", null: false
           t.integer "club_id", null: false, unsigned: true
           t.string  "string", null: false, collation: "ascii_bin"
@@ -85,7 +85,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
     let(:expected_dsl) do
       erbh(<<-ERB)
-        create_table "employee_clubs", <%= i cond("< 6.1", { id: :bigint, unsigned: true }, { id: { type: :bigint, unsigned: true } }) %>, force: :cascade do |t|
+        create_table "employee_clubs", id: { type: :bigint, unsigned: true }, force: :cascade do |t|
           t.integer "emp_no", null: false
           t.integer "club_id", null: false, unsigned: true
           t.string  "string", null: false, collation: "utf8mb4_bin"
@@ -109,7 +109,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
   context 'when change column (no change collation)' do
     let(:actual_dsl) do
       erbh(<<-ERB)
-        create_table "employee_clubs", <%= i cond("< 6.1", { id: :bigint, unsigned: true }, { id: { type: :bigint, unsigned: true } }) %>, force: :cascade do |t|
+        create_table "employee_clubs", id: { type: :bigint, unsigned: true }, force: :cascade do |t|
           t.integer "emp_no", null: false
           t.integer "club_id", null: false, unsigned: true
           t.string  "string", null: false, collation: "ascii_bin"

--- a/spec/mysql/dump/dump_class_method_spec.rb
+++ b/spec/mysql/dump/dump_class_method_spec.rb
@@ -7,12 +7,12 @@ describe 'Ridgepole::Client.dump' do
 
     it {
       expect(subject.dump(conn_spec, dump_without_table_options: true)).to match_fuzzy erbh(<<-ERB)
-        create_table "clubs", <%= i cond('< 6.1', { id: :integer, unsigned: true }, { id: { type: :integer, unsigned: true } }) %>, force: :cascade do |t|
+        create_table "clubs", id: { type: :integer, unsigned: true }, force: :cascade do |t|
           t.string "name", default: "", null: false
           t.index ["name"], name: "idx_name", unique: true
         end
 
-        create_table "departments", primary_key: "dept_no", <%= i cond(">= 6.1", { id: { type: :string, limit: 4 } }, { id: :string, limit: 4 }) %>, force: :cascade do |t|
+        create_table "departments", primary_key: "dept_no", id: { type: :string, limit: 4 }, force: :cascade do |t|
           t.string "dept_name", limit: 40, null: false
           t.index ["dept_name"], name: "dept_name", unique: true
         end
@@ -35,7 +35,7 @@ describe 'Ridgepole::Client.dump' do
           t.index ["emp_no"], name: "emp_no"
         end
 
-        create_table "employee_clubs", <%= i cond('< 6.1', { id: :integer, unsigned: true }, { id: { type: :integer, unsigned: true }}) %>, force: :cascade do |t|
+        create_table "employee_clubs", id: { type: :integer, unsigned: true }, force: :cascade do |t|
           t.integer "emp_no", null: false, unsigned: true
           t.integer "club_id", null: false, unsigned: true
           t.index ["emp_no", "club_id"], name: "idx_emp_no_club_id"

--- a/spec/mysql/dump/dump_spec.rb
+++ b/spec/mysql/dump/dump_spec.rb
@@ -7,12 +7,12 @@ describe 'Ridgepole::Client#dump' do
 
     it {
       expect(subject.dump).to match_fuzzy erbh(<<-ERB)
-        create_table "clubs", <%= i cond('< 6.1', { id: :integer, unsigned: true }, { id: { type: :integer, unsigned: true } }) %>, force: :cascade do |t|
+        create_table "clubs", id: { type: :integer, unsigned: true }, force: :cascade do |t|
           t.string "name", default: "", null: false
           t.index ["name"], name: "idx_name", unique: true
         end
 
-        create_table "departments", primary_key: "dept_no", <%= i cond(">= 6.1", { id: { type: :string, limit: 4 } }, { id: :string, limit: 4 }) %>, force: :cascade do |t|
+        create_table "departments", primary_key: "dept_no", id: { type: :string, limit: 4 }, force: :cascade do |t|
           t.string "dept_name", limit: 40, null: false
           t.index ["dept_name"], name: "dept_name", unique: true
         end
@@ -35,7 +35,7 @@ describe 'Ridgepole::Client#dump' do
           t.index ["emp_no"], name: "emp_no"
         end
 
-        create_table "employee_clubs", <%= i cond('< 6.1', { id: :integer, unsigned: true }, { id: { type: :integer, unsigned: true } }) %>, force: :cascade do |t|
+        create_table "employee_clubs", id: { type: :integer, unsigned: true }, force: :cascade do |t|
           t.integer "emp_no", null: false, unsigned: true
           t.integer "club_id", null: false, unsigned: true
           t.index ["emp_no", "club_id"], name: "idx_emp_no_club_id"

--- a/spec/mysql/dump/dump_unknown_column_type_spec.rb
+++ b/spec/mysql/dump/dump_unknown_column_type_spec.rb
@@ -7,7 +7,7 @@ describe 'Ridgepole::Client#dump' do
 
     it {
       expect(subject.dump).to match_fuzzy erbh(<<-ERB)
-        create_table "clubs", <%= i cond('< 6.1', { id: :integer, unsigned: true }, { id: { type: :integer, unsigned: true } }) %>, force: :cascade do |t|
+        create_table "clubs", id: { type: :integer, unsigned: true }, force: :cascade do |t|
           t.string "name", default: "", null: false
           t.index ["name"], name: "idx_name", unique: true
         end

--- a/spec/mysql/dump/dump_without_table_options_spec.rb
+++ b/spec/mysql/dump/dump_without_table_options_spec.rb
@@ -15,7 +15,7 @@ describe 'Ridgepole::Client#dump' do
   context 'when without table options' do
     let(:expected_dsl) do
       erbh(<<-ERB)
-        create_table "books", <%= i cond('>= 6.1', { id: { type: :bigint, unsigned: true } }, { id: :bigint, unsigned: true }) %>, force: :cascade, comment: "\\"london\\" bridge \\"is\\" falling \\"down\\"" do |t|
+        create_table "books", id: { type: :bigint, unsigned: true }, force: :cascade, comment: "\\"london\\" bridge \\"is\\" falling \\"down\\"" do |t|
           t.string   "title", null: false
           t.integer  "author_id", null: false
           t.datetime "created_at"

--- a/spec/mysql/fk/migrate_create_fk_spec.rb
+++ b/spec/mysql/fk/migrate_create_fk_spec.rb
@@ -254,10 +254,10 @@ describe 'Ridgepole::Client#diff -> migrate' do
   context 'when create fk with first key of multiple column indexes for its column' do
     let(:dsl) do
       erbh(<<-ERB, utf8: condition(:mysql80) ? 'utf8mb3' : 'utf8')
-        create_table "parent", id: :integer, force: :cascade, <%= i cond('>= 6.1', { charset: @utf8 }, { options: "ENGINE=InnoDB DEFAULT CHARSET=\#{@utf8}" }) %> do |t|
+        create_table "parent", id: :integer, force: :cascade, charset: "<%= @utf8 %>" do |t|
         end
 
-        create_table "child", force: :cascade, <%= i cond('>= 6.1', { charset: @utf8 }, { options: "ENGINE=InnoDB DEFAULT CHARSET=\#{@utf8}" }) %> do |t|
+        create_table "child", force: :cascade, charset: "<%= @utf8 %>" do |t|
           t.integer "parent_id"
           t.string "name"
           t.index ["parent_id", "name"], name: "par_id"
@@ -279,10 +279,10 @@ describe 'Ridgepole::Client#diff -> migrate' do
   context 'when create fk on the primary key' do
     let(:dsl) do
       erbh(<<-ERB, utf8: condition(:mysql80) ? 'utf8mb3' : 'utf8')
-        create_table "users", force: :cascade, <%= i cond('>= 6.1', { charset: @utf8 }, { options: "ENGINE=InnoDB DEFAULT CHARSET=\#{@utf8}" }) %> do |t|
+        create_table "users", force: :cascade, charset: "<%= @utf8 %>" do |t|
         end
 
-        create_table "icons", primary_key: "user_id", force: :cascade, <%= i cond('>= 6.1', { charset: @utf8 }, { options: "ENGINE=InnoDB DEFAULT CHARSET=\#{@utf8}" }) %> do |t|
+        create_table "icons", primary_key: "user_id", force: :cascade, charset: "<%= @utf8 %>" do |t|
         end
         add_foreign_key "icons", "users", name: "fk_icons_users"
       ERB
@@ -302,13 +302,13 @@ end
 context 'when create fk on the first primary key' do
   let(:dsl) do
     erbh(<<-ERB, utf8: condition(:mysql80) ? 'utf8mb3' : 'utf8')
-      create_table "users", id: :integer, force: :cascade, <%= i cond('>= 6.1', { charset: @utf8 }, { options: "ENGINE=InnoDB DEFAULT CHARSET=\#{@utf8}" }) %> do |t|
+      create_table "users", id: :integer, force: :cascade, charset: "<%= @utf8 %>" do |t|
       end
 
-      create_table "employee", id: :integer, force: :cascade, <%= i cond('>= 6.1', { charset: @utf8 }, { options: "ENGINE=InnoDB DEFAULT CHARSET=\#{@utf8}" }) %> do |t|
+      create_table "employee", id: :integer, force: :cascade, charset: "<%= @utf8 %>" do |t|
       end
 
-      create_table "icons", primary_key: ["user_id", "employee_id"], force: :cascade, <%= i cond('>= 6.1', { charset: @utf8 }, { options: "ENGINE=InnoDB DEFAULT CHARSET=\#{@utf8}" }) %> do |t|
+      create_table "icons", primary_key: ["user_id", "employee_id"], force: :cascade, charset: "<%= @utf8 %>" do |t|
         t.integer "user_id", null: false
         t.integer "employee_id", null: false
       end

--- a/spec/mysql/migrate/migrate_add_check_constraint_spec.rb
+++ b/spec/mysql/migrate/migrate_add_check_constraint_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe 'Ridgepole::Client#diff -> migrate', condition: [['>= 6.1', :mysql80]] do
+describe 'Ridgepole::Client#diff -> migrate', condition: [[:mysql80]] do
   context 'when add check constraint' do
     let(:actual_dsl) do
       erbh(<<-ERB)

--- a/spec/mysql/migrate/migrate_change_check_constraint_spec.rb
+++ b/spec/mysql/migrate/migrate_change_check_constraint_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe 'Ridgepole::Client#diff -> migrate', condition: [['>= 6.1', :mysql80]] do
+describe 'Ridgepole::Client#diff -> migrate', condition: [[:mysql80]] do
   context 'when change check constraint' do
     let(:actual_dsl) do
       erbh(<<-ERB)

--- a/spec/mysql/migrate/migrate_change_column8_spec.rb
+++ b/spec/mysql/migrate/migrate_change_column8_spec.rb
@@ -15,7 +15,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
 
   let(:actual_dsl) do
     erbh(<<-ERB)
-      create_table "employees", primary_key: "emp_no", force: :cascade, <%= i cond('>= 6.1', { charset: 'utf8' }, { options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8' }) %> do |t|
+      create_table "employees", primary_key: "emp_no", force: :cascade, charset: 'utf8' do |t|
       end
     ERB
   end

--- a/spec/mysql/migrate/migrate_change_column8_spec.rb
+++ b/spec/mysql/migrate/migrate_change_column8_spec.rb
@@ -27,38 +27,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
     ERB
   end
 
-  context 'when change options (no change)', condition: '< 6.1' do
-    let(:table_options) { "ENGINE=InnoDB DEFAULT CHARSET=#{condition(:mysql80) ? 'utf8mb3' : 'utf8'}" }
-
-    it {
-      expect(Ridgepole::Logger.instance).to_not receive(:verbose_info).with(warning_regexp)
-      delta = subject.diff(expected_dsl)
-      expect(delta.differ?).to be_falsey
-    }
-  end
-
-  context 'when change options (change)', condition: '< 6.1' do
-    let(:table_options) { 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4' }
-
-    it {
-      expect(Ridgepole::Logger.instance).to receive(:verbose_info).with(warning_regexp)
-      delta = subject.diff(expected_dsl)
-      expect(delta.differ?).to be_falsey
-    }
-  end
-
-  context 'when dump_without_table_options => true', condition: '< 6.1' do
-    let(:table_options) { 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4' }
-    let(:dump_without_table_options) { true }
-
-    it {
-      expect(Ridgepole::Logger.instance).to_not receive(:verbose_info).with(warning_regexp)
-      delta = subject.diff(expected_dsl)
-      expect(delta.differ?).to be_falsey
-    }
-  end
-
-  context 'when change options (no change)', condition: '>= 6.1' do
+  context 'when change options (no change)' do
     let(:table_hash_options) { { charset: condition(:mysql80) ? 'utf8mb3' : 'utf8' } }
 
     it {
@@ -68,7 +37,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
     }
   end
 
-  context 'when change options (change)', condition: '>= 6.1' do
+  context 'when change options (change)' do
     let(:table_hash_options) { { charset: 'utf8mb4' } }
 
     it {
@@ -78,7 +47,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
     }
   end
 
-  context 'when dump_without_table_options => true', condition: '>= 6.1' do
+  context 'when dump_without_table_options => true' do
     let(:table_hash_options) { { charset: 'utf8mb4' } }
     let(:dump_without_table_options) { true }
 

--- a/spec/mysql/migrate/migrate_change_index_spec.rb
+++ b/spec/mysql/migrate/migrate_change_index_spec.rb
@@ -220,16 +220,5 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
       RUBY
     }
-
-    # duplicated index checker is deleted in 6.1
-    # https://github.com/rails/rails/commit/edb23791d2ee9df89c5a4f24d72940ff8eaec8fc#diff-5a1c923abf3a794dbc133959167f794b2479ea8bcd0b1deda7766c22f05e8dfeL1198
-    it 'detects duplicated index', condition: '< 6.1' do
-      delta = client(bulk_change: true).diff(expected_dsl)
-
-      # XXX: Can not add an index of the same name
-      expect do
-        delta.migrate
-      end.to raise_error(/Index name 'emp_no' on table 'dept_emp' already exists/)
-    end
   end
 end

--- a/spec/mysql/migrate/migrate_check_relation_column_type_spec.rb
+++ b/spec/mysql/migrate/migrate_check_relation_column_type_spec.rb
@@ -68,7 +68,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date", null: false
         end
 
-        create_table "employees", <%= i cond(">= 6.1", { id: { type: :bigint, unsigned: true } }, { id: :bigint, unsigned: true }) %>, force: :cascade do |t|
+        create_table "employees", id: { type: :bigint, unsigned: true }, force: :cascade do |t|
           t.integer "emp_no", null: false
           t.date    "birth_date", null: false
           t.string  "first_name", limit: 14, null: false
@@ -88,7 +88,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date", null: false
         end
 
-        create_table "employees", <%= i cond(">= 6.1", { id: { type: :bigint, unsigned: true } }, { id: :bigint, unsigned: true }) %>, force: :cascade do |t|
+        create_table "employees", id: { type: :bigint, unsigned: true }, force: :cascade do |t|
           t.integer "emp_no", null: false
           t.date    "birth_date", null: false
           t.string  "first_name", limit: 14, null: false
@@ -179,7 +179,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date", null: false
         end
 
-        create_table "employees", <%= i cond(">= 6.1", { id: { type: :bigint, unsigned: true } }, { id: :bigint, unsigned: true }) %>, force: :cascade do |t|
+        create_table "employees", id: { type: :bigint, unsigned: true }, force: :cascade do |t|
           t.integer "emp_no", null: false
           t.date    "birth_date", null: false
           t.string  "first_name", limit: 14, null: false
@@ -199,7 +199,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.date    "to_date", null: false
         end
 
-        create_table "employees", <%= i cond(">= 6.1", { id: { type: :bigint, unsigned: true } }, { id: :bigint, unsigned: true }) %>, force: :cascade do |t|
+        create_table "employees", id: { type: :bigint, unsigned: true }, force: :cascade do |t|
           t.integer "emp_no", null: false
           t.date    "birth_date", null: false
           t.string  "first_name", limit: 14, null: false

--- a/spec/mysql/migrate/migrate_drop_check_constraint_spec.rb
+++ b/spec/mysql/migrate/migrate_drop_check_constraint_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe 'Ridgepole::Client#diff -> migrate', condition: [['>= 6.1', :mysql80]] do
+describe 'Ridgepole::Client#diff -> migrate', condition: [[:mysql80]] do
   context 'when drop check constraint' do
     let(:actual_dsl) do
       erbh(<<-ERB)

--- a/spec/mysql/migrate/migrate_primary_key_spec.rb
+++ b/spec/mysql/migrate/migrate_primary_key_spec.rb
@@ -3,7 +3,7 @@
 describe 'Ridgepole::Client#diff -> migrate' do
   let(:actual_dsl) do
     erbh(<<-ERB)
-      create_table "employees", <%= i cond(">= 6.1", { id: { type: :integer, unsigned: true } }, { id: :integer, unsigned: true }) %>, force: :cascade do |t|
+      create_table "employees", id: { type: :integer, unsigned: true }, force: :cascade do |t|
       end
     ERB
   end
@@ -25,7 +25,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
       it {
         expect(Ridgepole::Logger.instance).to receive(:warn).with(erbh(<<-ERB))
 [WARNING] Primary key definition of `employees` differ but `allow_pk_change` option is false
-  from: <%= i cond(">= 6.1", "{:id=>{:type=>:integer, :unsigned=>true}}", "{:id=>:integer, :unsigned=>true}") %>
+  from: {:id=>{:type=>:integer, :unsigned=>true}}
     to: {:id=>:bigint, :unsigned=>true}
         ERB
 
@@ -58,7 +58,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
     let(:allow_pk_change) { true }
     let(:expected_dsl) do
       erbh(<<-ERB)
-        create_table "employees", <%= i cond(">= 6.1", { id: { type: :bigint, unsigned: true } }, { id: :bigint, unsigned: true }) %>, force: :cascade do |t|
+        create_table "employees", id: { type: :bigint, unsigned: true }, force: :cascade do |t|
         end
 
         create_table "salaries", force: :cascade do |t|

--- a/spec/mysql/migrate/migrate_same_spec.rb
+++ b/spec/mysql/migrate/migrate_same_spec.rb
@@ -4,12 +4,12 @@ describe 'Ridgepole::Client#diff -> migrate' do
   context 'when database and definition are same' do
     let(:dsl) do
       erbh(<<-ERB)
-        create_table "clubs", <%= i cond('< 6.1', { id: :integer, unsigned: true }, { id: { type: :integer, unsigned: true } }) %>, force: :cascade do |t|
+        create_table "clubs", id: { type: :integer, unsigned: true }, force: :cascade do |t|
           t.string "name", default: "", null: false
           t.index ["name"], name: "idx_name", unique: true
         end
 
-        create_table "departments", primary_key: "dept_no", <%= i cond(">= 6.1", { id: { type: :string, limit: 4 } }, { id: :string, limit: 4 }) %>, force: :cascade do |t|
+        create_table "departments", primary_key: "dept_no", id: { type: :string, limit: 4 }, force: :cascade do |t|
           t.string "dept_name", limit: 40, null: false
           t.index ["dept_name"], name: "dept_name", unique: true
         end
@@ -32,7 +32,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.index ["emp_no"], name: "emp_no"
         end
 
-        create_table "employee_clubs", <%= i cond('< 6.1', { id: :integer, unsigned: true }, { id: { type: :integer, unsigned: true } }) %>, force: :cascade do |t|
+        create_table "employee_clubs", id: { type: :integer, unsigned: true }, force: :cascade do |t|
           t.integer "emp_no", null: false, unsigned: true
           t.integer "club_id", null: false, unsigned: true
           t.index ["emp_no", "club_id"], name: "idx_emp_no_club_id"

--- a/spec/mysql/text_blob_types/text_blob_types_spec.rb
+++ b/spec/mysql/text_blob_types/text_blob_types_spec.rb
@@ -45,7 +45,7 @@ describe 'Ridgepole::Client (with new text/blob types)' do
     end
   end
 
-  context 'when compare new types', condition: '>= 6.0.0.beta2' do
+  context 'when compare new types' do
     subject { client }
 
     before do

--- a/spec/mysql/text_blob_types/text_blob_types_spec.rb
+++ b/spec/mysql/text_blob_types/text_blob_types_spec.rb
@@ -26,7 +26,7 @@ describe 'Ridgepole::Client (with new text/blob types)' do
       delta.migrate
 
       expect(subject.dump).to match_ruby erbh(<<-ERB)
-        create_table "foos", <%= i cond(">= 6.1", { id: { type: :integer, unsigned: true } }, { id: :integer, unsigned: true }) %>, force: :cascade do |t|
+        create_table "foos", id: { type: :integer, unsigned: true }, force: :cascade do |t|
           t.binary  "blob"
           t.binary  "tiny_blob", size: :tiny
           t.binary  "medium_blob", size: :medium

--- a/spec/postgresql/dump/dump_spec.rb
+++ b/spec/postgresql/dump/dump_spec.rb
@@ -12,7 +12,7 @@ describe 'Ridgepole::Client#dump' do
           t.index ["name"], name: "idx_name", unique: true
         end
 
-        create_table "departments", primary_key: "dept_no", <%= i cond(">= 6.1", { id: { type: :string, limit: 4 } }, { id: :string, limit: 4 }) %>, force: :cascade do |t|
+        create_table "departments", primary_key: "dept_no", id: { type: :string, limit: 4 }, force: :cascade do |t|
           t.string "dept_name", limit: 40, null: false
           t.index ["dept_name"], name: "idx_dept_name", unique: true
         end

--- a/spec/postgresql/migrate/migrate_add_check_constraint_spec.rb
+++ b/spec/postgresql/migrate/migrate_add_check_constraint_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe 'Ridgepole::Client#diff -> migrate', condition: '>= 6.1' do
+describe 'Ridgepole::Client#diff -> migrate' do
   context 'when add check constraint' do
     let(:actual_dsl) do
       erbh(<<-ERB)

--- a/spec/postgresql/migrate/migrate_change_check_constraint_spec.rb
+++ b/spec/postgresql/migrate/migrate_change_check_constraint_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe 'Ridgepole::Client#diff -> migrate', condition: '>= 6.1' do
+describe 'Ridgepole::Client#diff -> migrate' do
   context 'when change check constraint' do
     let(:actual_dsl) do
       erbh(<<-ERB)

--- a/spec/postgresql/migrate/migrate_drop_check_constraint_spec.rb
+++ b/spec/postgresql/migrate/migrate_drop_check_constraint_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe 'Ridgepole::Client#diff -> migrate', condition: '>= 6.1' do
+describe 'Ridgepole::Client#diff -> migrate' do
   context 'when drop check constraint' do
     let(:actual_dsl) do
       erbh(<<-ERB)

--- a/spec/postgresql/migrate/migrate_same_spec.rb
+++ b/spec/postgresql/migrate/migrate_same_spec.rb
@@ -9,7 +9,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
           t.index ["name"], name: "idx_name", unique: true
         end
 
-        create_table "departments", primary_key: "dept_no", <%= i cond(">= 6.1", { id: { type: :string, limit: 4 } }, { id: :string, limit: 4 }) %>, force: :cascade do |t|
+        create_table "departments", primary_key: "dept_no", id: { type: :string, limit: 4 }, force: :cascade do |t|
           t.string "dept_name", limit: 40, null: false
           t.index ["dept_name"], name: "idx_dept_name", unique: true
         end

--- a/spec/spec_condition.rb
+++ b/spec/spec_condition.rb
@@ -16,10 +16,6 @@ module SpecCondition
       ENV['MYSQL80'] == '1'
     end
 
-    def activerecord_5?
-      (ActiveRecord::VERSION::MAJOR >= 5) && (ActiveRecord::VERSION::MAJOR < 6)
-    end
-
     def debug?
       ENV['DEBUG'] == '1'
     end


### PR DESCRIPTION
I drop support for Rails 5.1+5.2+6.0 and removed the code.

I am going to create a PR that will support Rails 7.1. 
7.1 will have destructive changes, so some tests will need new `cond(">= 7.1", ...) ` code.
I would like to cut off support for older rails, which is already EOL because of the complexity of the tests. What do you think?

NOTE: I don't think this PR should be merged into the minor version. I would be happy to create a new major version(2.0) branch.
