### PR TITLE
Support Trilogy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,7 @@ jobs:
           - MYSQL57=1
           - MYSQL80=1
           - POSTGRESQL=1
+          - TRILOGY=1
         gemfile:
           - gemfiles/activerecord_6.1.gemfile
           - gemfiles/activerecord_7.0.gemfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,11 @@ jobs:
           - gemfiles/activerecord_6.1.gemfile
           - gemfiles/activerecord_7.0.gemfile
           - gemfiles/activerecord_7.1.gemfile
+        exclude:
+          - gemfile: gemfiles/activerecord_6.1.gemfile
+            env: TRILOGY=1
+          - gemfile: gemfiles/activerecord_7.0.gemfile
+            env: TRILOGY=1
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
     steps:

--- a/lib/ridgepole/default_limit.rb
+++ b/lib/ridgepole/default_limit.rb
@@ -2,16 +2,19 @@
 
 module Ridgepole
   class DefaultsLimit
+    DEFAULT_LIMIT_FOR_MYSQL = {
+      boolean: 1,
+      integer: 4,
+      bigint: 8,
+      float: 24,
+      string: 255,
+      text: 65_535,
+      binary: 65_535,
+    }.freeze
+
     DEFAULTS_LIMITS = {
-      mysql2: {
-        boolean: 1,
-        integer: 4,
-        bigint: 8,
-        float: 24,
-        string: 255,
-        text: 65_535,
-        binary: 65_535,
-      },
+      mysql2: DEFAULT_LIMIT_FOR_MYSQL,
+      trilogy: DEFAULT_LIMIT_FOR_MYSQL,
     }.freeze
 
     class << self

--- a/ridgepole.gemspec
+++ b/ridgepole.gemspec
@@ -43,5 +43,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop-rspec', '>= 2.1.0'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'simplecov-lcov'
+  spec.add_development_dependency 'trilogy'
   spec.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/spec/mysql/cli/config_spec.rb
+++ b/spec/mysql/cli/config_spec.rb
@@ -4,11 +4,12 @@ describe Ridgepole::Config do
   subject { Ridgepole::Config.load(config, env, spec_name) }
 
   let(:spec_name) { '' }
+  let(:adapter) { condition(:trilogy_adapter) ? 'trilogy' : 'mysql2' }
 
   context 'when passed toplevel yaml' do
     let(:config) do
       <<-YAML.strip_heredoc
-        adapter: mysql2
+        adapter: #{adapter}
         encoding: utf8
         database: blog
         username: root
@@ -16,7 +17,7 @@ describe Ridgepole::Config do
     end
     let(:env) { 'development' }
     specify do
-      expect(subject['adapter']).to eq 'mysql2'
+      expect(subject['adapter']).to eq adapter
       expect(subject['encoding']).to eq 'utf8'
       expect(subject['database']).to eq 'blog'
       expect(subject['username']).to eq 'root'
@@ -26,7 +27,7 @@ describe Ridgepole::Config do
   context 'when passed dynamic yaml' do
     let(:config) do
       <<-YAML.strip_heredoc
-        adapter: mysql2
+        adapter: #{adapter}
         encoding: utf8
         database: blog_<%= 1 + 2 %>
         username: user_<%= 3 * 4 %>
@@ -34,7 +35,7 @@ describe Ridgepole::Config do
     end
     let(:env) { 'development' }
     specify do
-      expect(subject['adapter']).to eq 'mysql2'
+      expect(subject['adapter']).to eq adapter
       expect(subject['encoding']).to eq 'utf8'
       expect(subject['database']).to eq 'blog_3'
       expect(subject['username']).to eq 'user_12'
@@ -48,7 +49,7 @@ describe Ridgepole::Config do
           adapter: sqlspecifye
           database: db/sample.db
         production:
-          adapter: mysql2
+          adapter: #{adapter}
           encoding: utf8
           database: blog
           username: root
@@ -67,7 +68,7 @@ describe Ridgepole::Config do
     context 'in production env' do
       let(:env) { 'production' }
       specify do
-        expect(subject['adapter']).to eq 'mysql2'
+        expect(subject['adapter']).to eq adapter
         expect(subject['encoding']).to eq 'utf8'
         expect(subject['database']).to eq 'blog'
         expect(subject['username']).to eq 'root'
@@ -78,7 +79,7 @@ describe Ridgepole::Config do
   context 'when passed yaml file' do
     let(:config) do
       <<-YAML.strip_heredoc
-        adapter: mysql2
+        adapter: #{adapter}
         encoding: utf8
         database: blog
         username: root
@@ -90,7 +91,7 @@ describe Ridgepole::Config do
         f.puts config
         f.flush
 
-        expect(subject['adapter']).to eq 'mysql2'
+        expect(subject['adapter']).to eq adapter
         expect(subject['encoding']).to eq 'utf8'
         expect(subject['database']).to eq 'blog'
         expect(subject['username']).to eq 'root'
@@ -113,11 +114,11 @@ describe Ridgepole::Config do
   end
 
   context 'when passed DATABASE_URL' do
-    let(:config) { 'mysql2://root:pass@127.0.0.1:3307/blog?pool=5&reaping_frequency=2' }
+    let(:config) { "#{adapter}://root:pass@127.0.0.1:3307/blog?pool=5&reaping_frequency=2" }
     let(:env) { 'development' }
 
     it {
-      expect(subject['adapter']).to eq 'mysql2'
+      expect(subject['adapter']).to eq adapter
       expect(subject['database']).to eq 'blog'
       expect(subject['username']).to eq 'root'
       expect(subject['password']).to eq 'pass'
@@ -145,11 +146,11 @@ describe Ridgepole::Config do
     let(:env) { 'development' }
 
     before do
-      allow(ENV).to receive(:fetch).with('DATABASE_URL').and_return('mysql2://root:pass@127.0.0.1:3307/blog')
+      allow(ENV).to receive(:fetch).with('DATABASE_URL').and_return("#{adapter}://root:pass@127.0.0.1:3307/blog")
     end
 
     it {
-      expect(subject['adapter']).to eq 'mysql2'
+      expect(subject['adapter']).to eq adapter
       expect(subject['database']).to eq 'blog'
       expect(subject['username']).to eq 'root'
       expect(subject['password']).to eq 'pass'
@@ -166,12 +167,12 @@ describe Ridgepole::Config do
             database: db/sample.db
         production:
           primary:
-            adapter: mysql2
+            adapter: #{adapter}
             encoding: utf8
             database: blog
             username: root
           primary_replica:
-            adapter: mysql2
+            adapter: #{adapter}
             encoding: utf8
             database: blog
             username: readonly
@@ -192,7 +193,7 @@ describe Ridgepole::Config do
       let(:env) { 'production' }
       let(:spec_name) { 'primary' }
       specify do
-        expect(subject['adapter']).to eq 'mysql2'
+        expect(subject['adapter']).to eq adapter
         expect(subject['encoding']).to eq 'utf8'
         expect(subject['database']).to eq 'blog'
         expect(subject['username']).to eq 'root'

--- a/spec/mysql/migrate/migrate_execute_spec.rb
+++ b/spec/mysql/migrate/migrate_execute_spec.rb
@@ -29,7 +29,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         execute("ALTER TABLE books ADD CONSTRAINT fk_author FOREIGN KEY (author_id) REFERENCES authors (id)") do |c|
-          c.raw_connection.query("SELECT 1 FROM information_schema.key_column_usage WHERE TABLE_SCHEMA = '<%= TEST_SCHEMA %>' AND CONSTRAINT_NAME = 'fk_author' LIMIT 1").each.length.zero?
+          c.raw_connection.query("SELECT 1 FROM information_schema.key_column_usage WHERE TABLE_SCHEMA = '<%= TEST_SCHEMA %>' AND CONSTRAINT_NAME = 'fk_author' LIMIT 1").to_a.length.zero?
         end
       ERB
     end
@@ -100,7 +100,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         execute("ALTER TABLE books ADD CONSTRAINT fk_author FOREIGN KEY (author_id) REFERENCES authors (id)") do |c|
-          c.raw_connection.query("SELECT 1 FROM information_schema.key_column_usage WHERE TABLE_SCHEMA = '<%= TEST_SCHEMA %>' AND CONSTRAINT_NAME = 'fk_author' LIMIT 1").each.length.zero?
+          c.raw_connection.query("SELECT 1 FROM information_schema.key_column_usage WHERE TABLE_SCHEMA = '<%= TEST_SCHEMA %>' AND CONSTRAINT_NAME = 'fk_author' LIMIT 1").to_a.length.zero?
         end
 
         add_foreign_key "books", "authors", name: "fk_author"
@@ -171,7 +171,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         execute("ALTER TABLE books ADD CONSTRAINT fk_author FOREIGN KEY (author_id) REFERENCES authors (id)") do |c|
-          c.raw_connection.query("SELECT 1 FROM information_schema.key_column_usage WHERE TABLE_SCHEMA = '<%= TEST_SCHEMA %>' AND CONSTRAINT_NAME = 'fk_author' LIMIT 1").each.length.zero?
+          c.raw_connection.query("SELECT 1 FROM information_schema.key_column_usage WHERE TABLE_SCHEMA = '<%= TEST_SCHEMA %>' AND CONSTRAINT_NAME = 'fk_author' LIMIT 1").to_a.length.zero?
         end
       ERB
     end
@@ -241,7 +241,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
         end
 
         execute("ALTER TABLE books ADD CONSTRAINT fk_author FOREIGN KEY (author_id) REFERENCES authors (id)") do |c|
-          c.raw_connection.query("SELECT 1 FROM information_schema.key_column_usage WHERE TABLE_SCHEMA = '<%= TEST_SCHEMA %>' AND CONSTRAINT_NAME = 'fk_author' LIMIT 1").each.length.zero?
+          c.raw_connection.query("SELECT 1 FROM information_schema.key_column_usage WHERE TABLE_SCHEMA = '<%= TEST_SCHEMA %>' AND CONSTRAINT_NAME = 'fk_author' LIMIT 1").to_a.length.zero?
         end
 
         add_foreign_key "books", "authors", name: "fk_author"

--- a/spec/spec_condition.rb
+++ b/spec/spec_condition.rb
@@ -16,6 +16,10 @@ module SpecCondition
       ENV['MYSQL80'] == '1'
     end
 
+    def trilogy_adapter?
+      ENV['TRILOGY'] == '1'
+    end
+
     def debug?
       ENV['DEBUG'] == '1'
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -123,8 +123,9 @@ module SpecHelper
         password: TEST_PG_PASS,
       }.merge(config)
     else
+      adapter = condition(:trilogy_adapter) ? 'trilogy' : 'mysql2'
       {
-        adapter: 'mysql2',
+        adapter: adapter,
         database: TEST_SCHEMA,
         host: TEST_MYSQL_HOST,
         port: TEST_MYSQL_PORT,


### PR DESCRIPTION
GitHub introduced a client library for MySQL-compatible called Trilogy.
https://github.blog/2022-08-25-introducing-trilogy-a-new-database-adapter-for-ruby-on-rails/

Rails 7.1 introduces the adapter for Trilogy officially.
https://guides.rubyonrails.org/7_1_release_notes.html#introduce-adapter-for-trilogy

This PR adds Trilogy support to `ridgepole`. This PR only considers Rails 7.1 because Rails added the official support in the version.
But, the Trilogy team provides the gem to support old Rails versions. [trilogy-libraries/activerecord-trilogy-adapter](https://github.com/trilogy-libraries/activerecord-trilogy-adapter). If we need it, I will add support to this gem too.
