### PR TITLE
add spec 'when renamed_from column option is set for new table'

### DIFF
--- a/spec/postgresql/migrate/migrate_renamed_from_column_spec.rb
+++ b/spec/postgresql/migrate/migrate_renamed_from_column_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+describe 'Ridgepole::Client#diff -> migrate' do
+  context 'when renamed_from column option is set for new table' do
+    let(:actual_dsl) do
+      erbh(<<-ERB)
+        create_table "clubs", force: :cascade do |t|
+          t.string "name", limit: 255, default: "", null: false, renamed_from: "name_old"
+        end
+      ERB
+    end
+
+    let(:expected_dsl) do
+      erbh(<<-ERB)
+        create_table "clubs", force: :cascade do |t|
+          t.string "name", limit: 255, default: "", null: false
+        end
+      ERB
+    end
+
+    subject { client }
+
+    before { subject.diff(actual_dsl).migrate }
+
+    it 'ignores renamed_form column option' do
+      expect(subject.dump).to match_ruby expected_dsl
+    end
+  end
+end


### PR DESCRIPTION
## what is it ?

bug report ridgepole 2.0 with ActiveRecord 7.1

## summary

if `renamed_from` column option is set for new table, error raises if AR 7.1

## why?

ActiveRecord::Schema option checking is strict

```
     Failure/Error: ActiveRecord::Schema.new.instance_eval(script, SCRIPT_NAME, 1) unless script.empty?
     
     RuntimeError:
       Unknown key: :renamed_from. Valid keys are: :limit, :precision, :scale, :default, :null, :collation, :comment, :primary_key, :if_exists, :if_not_exists, :array, :using, :cast_as, :as, :type, :enum_type, :stored
         1: create_table("clubs", **{}) do |t|
       * 2:   t.column("name", :"string", **{:limit=>255, :default=>"", :null=>false, :renamed_from=>"name_old"})
         3: end
     # <Schema>:2:in `block (2 levels) in eval_script'
     # <Schema>:1:in `block in eval_script'
     # ./lib/ridgepole/delta.rb:115:in `instance_eval'
     # ./lib/ridgepole/delta.rb:115:in `block in eval_script'
     # ./lib/ridgepole/delta.rb:173:in `with_pre_post_query'
     # ./lib/ridgepole/delta.rb:114:in `eval_script'
     # ./lib/ridgepole/delta.rb:104:in `migrate0'
     # ./lib/ridgepole/delta.rb:24:in `migrate'
     # ./spec/postgresql/migrate/migrate_renamed_from_column_spec.rb:23:in `block (3 levels) in <top (required)>'
```
