### PR TITLE
Fixed a bug that caused renamed_from to error as an invalid option.

### DIFF
--- a/lib/ridgepole/delta.rb
+++ b/lib/ridgepole/delta.rb
@@ -4,6 +4,10 @@ module Ridgepole
   class Delta
     SCRIPT_NAME = '<Schema>'
 
+    RIDGEPOLE_OPTIONS = %i[
+      renamed_from
+    ].freeze
+
     def initialize(delta, options = {})
       @delta = delta
       @options = options
@@ -235,7 +239,7 @@ create_table(#{table_name.inspect}, #{inspect_options_include_default_proc(optio
         normalize_limit(column_type, column_options)
 
         buf.puts(<<-RUBY)
-  t.column(#{column_name.inspect}, :#{column_type.to_s.inspect}, #{inspect_options_include_default_proc(column_options)})
+  t.column(#{column_name.inspect}, :#{column_type.to_s.inspect}, #{inspect_options_include_default_proc(normalize_options(column_options))})
       RUBY
       end
 
@@ -644,6 +648,12 @@ remove_unique_constraint(#{table_name.inspect}, #{column_name.inspect}, **#{attr
     def normalize_limit(column_type, column_options)
       default_limit = Ridgepole::DefaultsLimit.default_limit(column_type, @options)
       column_options[:limit] ||= default_limit if default_limit
+    end
+
+    def normalize_options(options)
+      opts = options.dup
+      RIDGEPOLE_OPTIONS.each { opts.delete(_1) }
+      opts
     end
 
     def inspect_options_include_default_proc(options)

--- a/spec/mysql/migrate/migrate_rename_column_spec.rb
+++ b/spec/mysql/migrate/migrate_rename_column_spec.rb
@@ -181,4 +181,30 @@ describe 'Ridgepole::Client#diff -> migrate' do
       end.to raise_error('Column `age` not found')
     }
   end
+
+  context 'when renamed_from column option is set for new table' do
+    let(:actual_dsl) do
+      erbh(<<-ERB)
+        create_table "clubs", force: :cascade do |t|
+          t.string "name", renamed_from: "name_old"
+        end
+      ERB
+    end
+
+    let(:expected_dsl) do
+      erbh(<<-ERB)
+        create_table "clubs", force: :cascade do |t|
+          t.string "name"
+        end
+      ERB
+    end
+
+    subject { client }
+
+    before { subject.diff(actual_dsl).migrate }
+
+    it 'ignores renamed_form column option' do
+      expect(subject.dump).to match_ruby expected_dsl
+    end
+  end
 end


### PR DESCRIPTION
Fixed: #452

In Rails 7.1, arguments other than allowed options cannot be passed.
The option `renamed_from` used in ridgepole was causing an error as an invalid option, so I fixed it to be excluded.