### PR TITLE
Added the help command and adapter name to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Or install it yourself as:
 
 ## Help
 ```
+$ ridgepole -h(or --help)
 Usage: ridgepole [options]
     -c, --config CONF_OR_FILE
     -E, --env ENVIRONMENT

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ $ git init
 Initialized empty Git repository in ...
 
 $ cat config.yml
-adapter: mysql2
+adapter: mysql2(or postgresql)
 encoding: utf8
 database: blog
 username: root


### PR DESCRIPTION
I use this gem regularly. I'm very grateful for it as it saves me the trouble and effort involved in migration tasks.

I thought it would be good to add the following two points after reading the README, so I added them.

- I have explicitly added a command to make it clear that it is for outputting help.
- I have modified the example in the config.yml to make it clear and easy to understand which adapters can be used when utilizing it.

Additionally, I thought it might be a good idea to explicitly write down the adapters that can be used with this gem in the documentation. What do you think?