### PR TITLE
Add test case when single quote is in table comment

### DIFF
--- a/spec/mysql/migrate/migrate_change_table_comment_spec.rb
+++ b/spec/mysql/migrate/migrate_change_table_comment_spec.rb
@@ -10,6 +10,9 @@ describe 'Ridgepole::Client#diff -> migrate' do
         t.string "gender", limit: 1, null: false
         t.date   "hire_date", null: false
       end
+
+      create_table "tenants", force: :cascade, comment: "old comment '" do |t|
+      end
     ERB
   end
 
@@ -21,6 +24,9 @@ describe 'Ridgepole::Client#diff -> migrate' do
         t.string "last_name", limit: 16, null: false
         t.string "gender", limit: 1, null: false
         t.date   "hire_date", null: false
+      end
+
+      create_table "tenants", force: :cascade, comment: "new comment '" do |t|
       end
     ERB
   end
@@ -36,6 +42,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
 # Table option changes are ignored on `employees`.
   from: {:comment=>"old comment"}
     to: {:comment=>"new comment"}
+      MSG
+      expect(Ridgepole::Logger.instance).to receive(:verbose_info).once.with(<<-MSG)
+# Table option changes are ignored on `tenants`.
+  from: {:comment=>"old comment '"}
+    to: {:comment=>"new comment '"}
       MSG
       delta = subject.diff(expected_dsl)
       expect(delta.differ?).to be_falsey


### PR DESCRIPTION
## What

As a title.
I fixed that by doubling the backslashs.

## Why

In the current version (2.0.1), including single quotes in table comments results in an error.
```rb
# Schemafile
create_table "users", comment: "'" do |t|
end
```
```shell
$ ridgepole -c config.yml --apply --file test.schema --mysql-change-table-comment
Apply `Schemafile`

-- execute("ALTER TABLE `users` COMMENT='''")
[ERROR] Mysql2::Error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ''''' at line 1
* 1: execute "ALTER TABLE `users` COMMENT='\''"
	/Users/wada.mitsuaki/.local/share/mise/installs/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/mysql2-0.5.6/lib/mysql2/client.rb:151:in `_query'
```

The cause is that the number of backslashes for escaping is only half of the required amount. [Here](https://github.com/ridgepole/ridgepole/blob/7198ff507b0ac3592cd41f4fb30ffb023d51ffab/lib/ridgepole/delta.rb#L310-L312), since the output is being made by puts, half of the necessary amount is removed.

```rb
# ⛔ Current version
execute "ALTER TABLE `users` COMMENT='\''"

# ✅ Required (At this patch)
execute "ALTER TABLE `users` COMMENT='\\''"
```

Therefore, I doubled the backslashes to fix that.

## Test at local

```rb
# Schemafile
create_table "users", comment: "'" do |t|
end
```

```shell
$ bin/ridgepole -c config.yml --apply --file test.schema --drop-table --mysql-change-table-comment
Apply `test.schema`
-- create_table("users", {:comment=>"'"})
   -> 0.0093s

$ mysql -uroot
mysql> SHOW CREATE TABLE my_db.users;
+-------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Table | Create Table                                                                                                                                                       |
+-------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| users | CREATE TABLE `users` (
  `id` bigint NOT NULL AUTO_INCREMENT,
  PRIMARY KEY (`id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='''' |
+-------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.01 sec)
```