### PR TITLE
Chore: Rubocop, Ignore Schemafile and *.schema files

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,8 @@ AllCops:
     - "gemfiles/**/*"
     - "omnibus-ridgepole/**/*"
     - "vendor/bundle/**/*"
+    - "Schemafile"
+    - "**/*.schema"
   TargetRubyVersion: 2.7
   NewCops: enable
   SuggestExtensions: false


### PR DESCRIPTION
## What

Rubocop, Ignore Schemafile and *.schema files.

## Why

To improve Developer Experience. The linter fails on the Schemafile for testing, causing it to become noise.

## Motivation for this change.

It is when I ran the test as per the README instructions. Once you run it once, a Schemafile is created. Then, when you run it a second time, the Schemafile is the target of rubocop and the lint fails. Therefore, subsequent tests are not executed.