### PR TITLE
Fix append_change_table_options

### DIFF
--- a/lib/ridgepole/delta.rb
+++ b/lib/ridgepole/delta.rb
@@ -308,7 +308,7 @@ drop_table(#{table_name.inspect})
     def append_change_table_options(table_name, table_options, buf)
       # XXX: MySQL only
       buf.puts(<<-RUBY)
-execute "ALTER TABLE #{ActiveRecord::Base.connection.quote_table_name(table_name)} #{table_options}"
+execute "ALTER TABLE #{ActiveRecord::Base.connection.quote_table_name(table_name)} #{table_options.dump[1..-2]}"
     RUBY
 
       buf.puts


### PR DESCRIPTION
- from https://github.com/ridgepole/ridgepole/pull/467

In the `append_change_table_options` method, `table_options` was not escaping for Ruby strings, so make it escape.