### PR TITLE
Cleanup codes for old Rubies

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ bundle exec appraisal activerecord-7.0 rake
 # MYSQL80=1 bundle exec appraisal activerecord-7.0 rake
 ```
 
-**Notice:** Ruby 2.6 or above/mysql-client/postgresql-client is required.
+**Notice:** Ruby 2.7 or above/mysql-client/postgresql-client is required.
 
 ## Demo
 

--- a/bin/ridgepole
+++ b/bin/ridgepole
@@ -86,8 +86,7 @@ ARGV.options do |opt|
   opt.on('',   '--dry-run') { options[:dry_run] = true }
   opt.on('',   '--table-options OPTIONS') { |v| options[:table_options] = v }
   opt.on('',   '--table-hash-options OPTIONS') do |v|
-    # NOTE: Ruby2.4 doesn't support `symbolize_names: true`
-    hash = YAML.safe_load(v).deep_symbolize_keys
+    hash = YAML.safe_load(v, symbolize_names: true)
 
     case hash[:id]
     when String

--- a/bin/ridgepole
+++ b/bin/ridgepole
@@ -264,15 +264,13 @@ begin
         else
           File.open(diff_file)
         end
-      elsif Gem::Version.new(Psych::VERSION) >= Gem::Version.new('3.1.0.pre1') # Ruby 2.6
+      else
         YAML.safe_load(
           diff_file,
           permitted_classes: [],
           permitted_symbols: [],
           aliases: true
         )
-      else
-        YAML.safe_load(diff_file, [], [], true)
       end
     end
 

--- a/lib/ridgepole/cli/config.rb
+++ b/lib/ridgepole/cli/config.rb
@@ -13,15 +13,13 @@ module Ridgepole
                           parse_config_file(config)
                         elsif (expanded = File.expand_path(config)) && File.exist?(expanded)
                           parse_config_file(expanded)
-                        elsif Gem::Version.new(Psych::VERSION) >= Gem::Version.new('3.1.0.pre1') # Ruby 2.6
+                        else
                           YAML.safe_load(
                             ERB.new(config).result,
                             permitted_classes: [],
                             permitted_symbols: [],
                             aliases: true
                           )
-                        else
-                          YAML.safe_load(ERB.new(config).result, [], [], true)
                         end
 
         parsed_config = parse_database_url(config) unless parsed_config.is_a?(Hash)
@@ -39,17 +37,12 @@ module Ridgepole
 
       def parse_config_file(path)
         yaml = ERB.new(File.read(path)).result
-
-        if Gem::Version.new(Psych::VERSION) >= Gem::Version.new('3.1.0.pre1') # Ruby 2.6
-          YAML.safe_load(
-            yaml,
-            permitted_classes: [],
-            permitted_symbols: [],
-            aliases: true
-          )
-        else
-          YAML.safe_load(yaml, [], [], true)
-        end
+        YAML.safe_load(
+          yaml,
+          permitted_classes: [],
+          permitted_symbols: [],
+          aliases: true
+        )
       end
 
       def parse_database_url(config)


### PR DESCRIPTION
This PR did a small refactoring that fixed the code for old Rubies.

* Use `symbolize_names` option instead of `deep_symbolize_keys`
* Remove needless branch for `YAML.safe_load`
* Fix required Ruby version in README