### PR TITLE
add spec for require_relative

### DIFF
--- a/spec/dsl_parser/context_spec.rb
+++ b/spec/dsl_parser/context_spec.rb
@@ -5,7 +5,7 @@ describe Ridgepole::DSLParser::Context do
     subject { context.require_relative(relative_path) }
 
     let!(:context) do
-      Ridgepole::DSLParser::Context.new
+      Ridgepole::DSLParser::Context.new(path: __FILE__)
     end
     let!(:relative_path) do
       '../fixtures/for_require_relative_spec.rb'

--- a/spec/fixtures/children/for_require_relative_spec.rb
+++ b/spec/fixtures/children/for_require_relative_spec.rb
@@ -1,5 +1,3 @@
 # frozen_string_literal: true
 
-require_relative 'children/for_require_relative_spec'
-
 'This file is used by dsl_parser/context_spec.'


### PR DESCRIPTION
just add spec 

## background
on rails application(7.1.3.2) with Ruby 3.3, I met an issue with code below.

```rb
# bin/ridgepole(+x)
#!/usr/bin/env ruby
require 'ridgepole'
require 'ridgepole/cli/config'

path = 'Schemafile'
env = ENV['RAILS_ENV'] || 'development'

client = Ridgepole::Client.new(Ridgepole::Config.load('config/database.yml', env))
dsl = File.read(path)
delta = client.diff(dsl) # <= `path` is not passed
delta.migrate if delta.differ?

# ./Schemafile
require_relative './lib/ridgepole/my_customize'
```

```sh
$ bin/ridgepole
<internal:/Users/kakubin/.rbenv/versions/3.3.1/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:37:in `require': cannot load such file -- /Users/kakubin/sample-rails-application/(eval at /Users/kakubin/ridgepole/lib/ridgepole/dsl_parser/lib/ridgepole/my_customize (LoadError)
```

And this is how values were resolved in the method `require_relative`.

```irb
irb(#<Ridgepole::DSLParser::Conte...):001:0> File.dirname(caller[0])
=> "/Users/kakubin/.rbenv/versions/3.3.1/lib/ruby/gems/3.3.0/gems/irb-1.12.0/lib/irb"
irb(#<Ridgepole::DSLParser::Conte...):002:0> File.expand_path(relative_path, File.dirname(caller[0]))
=> "/Users/kakubin/.rbenv/versions/3.3.1/lib/ruby/gems/3.3.0/gems/irb-1.12.0/lib/irb/lib/ridgepole/my_customize"
```

Because of lack of an argument `path` for `Ridgepole::Client#diff`, `Schemafile` is [evaluated under `(eval)` ](https://docs.ruby-lang.org/ja/latest/method/BasicObject/i/instance_eval.html) and `caller[0]` return anything but 'Schemafile'.

https://github.com/ridgepole/ridgepole/blob/0481fdf64ec8d4341bc936558c2d6c3f5cc37214/lib/ridgepole/dsl_parser/context.rb#L14-L21

To fix it, I just have to add argument `path` and no need to modify `Ridgepole::DSLParser::Context` in conclusion.

this issue is not reproduced with ruby 3.2 or below.