### PR TITLE
Fix installation command in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Add this line to your application's Gemfile:
 
 And then execute:
 
-    $ bundle
+    $ bundle install
 
 Or install it yourself as:
 


### PR DESCRIPTION
We found some of the commands listed in the installation section were missing.
Therefore, the missing commands was added.
<!--
Thank you for your pull request.
It would be helpful if you could clarify the problem by creating an issue first.
-->
