### PR TITLE
Use `docker compose` instead of removed `docker-compose`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
           bundler-cache: true
       - name: Setup dependencies
         run: |
-          for i in {1..60}; do docker-compose up -d && break; sleep 1; done
+          for i in {1..60}; do docker compose up -d && break; sleep 1; done
           # Wait until database servers start
           function mysql57_ping { mysqladmin -u root -h 127.0.0.1 -P 13316 ping; }
           function mysql80_ping { mysqladmin -u root -h 127.0.0.1 -P 13318 ping; }


### PR DESCRIPTION
Docker Compose v1 was already removed from the images on GitHub Actions. Ref: https://github.com/actions/runner-images/issues/9557
