### PR TITLE
Add `logger` gem as an explicit dependency

### DIFF
--- a/ridgepole.gemspec
+++ b/ridgepole.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'activerecord', '>= 6.1', '< 8.0'
   spec.add_dependency 'diffy'
+  spec.add_dependency 'logger'
 
   spec.add_development_dependency 'appraisal', '>= 2.2.0'
   spec.add_development_dependency 'bigdecimal'


### PR DESCRIPTION
`logger` will be a bundled gem from Ruby 3.5.
https://bugs.ruby-lang.org/issues/20309

So if you use `logger` as the standard library, Bundler shows the following warning.

```
warning: logger was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
```

I'm not sure why yet, but it seems that the above message has showsn since Ruby 3.3.5. This message has broken specs.
https://github.com/ridgepole/ridgepole/actions/runs/10765746072/job/29850451424?pr=501

Regardless of the cause, we need to add `logger` to a dependency to keep using `logger`.  This PR adds `logger` gem as a runtime dependency.

<!--
Thank you for your pull request.
It would be helpful if you could clarify the problem by creating an issue first.
-->
