### PR TITLE
Remove column quotation on scanning check_constraint changes

### DIFF
--- a/spec/postgresql/migrate/migrate_change_check_constraint_spec.rb
+++ b/spec/postgresql/migrate/migrate_change_check_constraint_spec.rb
@@ -62,4 +62,34 @@ describe 'Ridgepole::Client#diff -> migrate' do
       expect(subject.dump).to match_ruby expected_dsl
     }
   end
+
+  context 'when do not change check constraint (but quoted)' do
+    let(:actual_dsl) do
+      erbh(<<-ERB)
+        create_table "clubs", force: :cascade do |t|
+          t.bigint "value", null: false
+          t.check_constraint '"value" > 0', name: "value_check"
+        end
+      ERB
+    end
+
+    let(:expected_dsl) do
+      erbh(<<-ERB)
+        create_table "clubs", force: :cascade do |t|
+          t.bigint "value", null: false
+          t.check_constraint "value > 0", name: "value_check"
+        end
+      ERB
+    end
+
+    before { subject.diff(expected_dsl).migrate }
+    subject { client }
+
+    it {
+      delta = subject.diff(actual_dsl)
+      expect(delta.differ?).to be_falsey
+      delta.migrate
+      expect(subject.dump).to match_ruby expected_dsl
+    }
+  end
 end


### PR DESCRIPTION
# What
Remove column quotation( \` in mysql / `"` in postgres or ANSI SQL) on scanning check_constraint changes

# Why
To ensure semantic equivalence when detecting changes on check_constraints, it might be better to remove quotations.

On check constraint, the column identifier may be quoted or unquoted. In most case, the both case is correct. Quotation for column identifiers are optional unless the identifier is a reserved.
(ex. mysql 8.0 - https://dev.mysql.com/doc/refman/8.0/en/identifiers.html)

Besides, it seems there's no guarantee that dump outputs are consistently quoted. Also the default behavior varies between database types.
(ex: mysql 8.0 → quoted by default / postgres 17 → NOT quoted by default)

The expression of column identifiers in both the dump and Schemafile might vary.
To ensure **semantic** equivalence, it might be better to remove quotations uniformly when scanning changes on check_constraints.


**NOTE:**
Recently, I encountered an issue where check_constraint definitions were being removed and re-added in every migration due to inconsistencies in the presence or absence of quotation marks. This behavior brought the issue to my attention.