### PR TITLE
CI against Ruby 3.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,7 @@ jobs:
           - "3.1"
           - "3.2"
           - "3.3"
+          - "3.4"
         env:
           - MYSQL57=1
           - MYSQL80=1
@@ -44,6 +45,10 @@ jobs:
             env: TRILOGY=1
           - gemfile: gemfiles/activerecord_7.0.gemfile
             env: TRILOGY=1
+          - ruby: "3.4"
+            gemfile: gemfiles/activerecord_6.1.gemfile
+          - ruby: "3.4"
+            gemfile: gemfiles/activerecord_7.0.gemfile
           - ruby: "3.3"
             gemfile: gemfiles/activerecord_6.1.gemfile
           - ruby: "3.3"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -58,3 +58,5 @@ Style/OptionalBooleanParameter:
   Enabled: false
 Gemspec/DevelopmentDependencies:
   Enabled: false
+Lint/LiteralInInterpolation:
+  Enabled: false

--- a/spec/mysql/cli/ridgepole_spec.rb
+++ b/spec/mysql/cli/ridgepole_spec.rb
@@ -74,7 +74,7 @@ describe 'ridgepole' do
 
       expect(status.success?).to be_truthy
       expect(out).to match_fuzzy <<-MSG
-        Ridgepole::Client#initialize([#{conn_spec_str('ridgepole_test')}, {:dry_run=>false, :debug=>false, :color=>false}])
+        Ridgepole::Client#initialize([#{conn_spec_str('ridgepole_test')}, #{{ dry_run: false, debug: false, color: false }}])
         # Export Schema
         Ridgepole::Client#dump
       MSG
@@ -86,7 +86,7 @@ describe 'ridgepole' do
 
         expect(status.success?).to be_truthy
         expect(out).to match_fuzzy <<-MSG
-          Ridgepole::Client#initialize([#{conn_spec_str('ridgepole_test')}, {:dry_run=>false, :debug=>false, :color=>false}])
+          Ridgepole::Client#initialize([#{conn_spec_str('ridgepole_test')}, #{{ dry_run: false, debug: false, color: false }}])
           Export Schema to `#{f.path}`
           Ridgepole::Client#dump
         MSG
@@ -98,7 +98,7 @@ describe 'ridgepole' do
 
       expect(status.success?).to be_truthy
       expect(out).to match_fuzzy <<-MSG
-        Ridgepole::Client#initialize([#{conn_spec_str('ridgepole_test')}, {:dry_run=>false, :debug=>false, :color=>false}])
+        Ridgepole::Client#initialize([#{conn_spec_str('ridgepole_test')}, #{{ dry_run: false, debug: false, color: false }}])
         # Export Schema
         Ridgepole::Client#dump
       MSG
@@ -109,7 +109,7 @@ describe 'ridgepole' do
 
       expect(status.success?).to be_truthy
       expect(out).to match_fuzzy <<-MSG
-        Ridgepole::Client#initialize([#{conn_spec_str('ridgepole_test')}, {:dry_run=>false, :debug=>false, :color=>false}])
+        Ridgepole::Client#initialize([#{conn_spec_str('ridgepole_test')}, #{{ dry_run: false, debug: false, color: false }}])
         Export Schema
         Ridgepole::Client#dump
           write `Schemafile`
@@ -122,7 +122,7 @@ describe 'ridgepole' do
 
         expect(status.success?).to be_truthy
         expect(out).to match_fuzzy <<-MSG
-          Ridgepole::Client#initialize([#{conn_spec_str('ridgepole_test')}, {:dry_run=>false, :debug=>false, :color=>false}])
+          Ridgepole::Client#initialize([#{conn_spec_str('ridgepole_test')}, #{{ dry_run: false, debug: false, color: false }}])
           Export Schema
           Ridgepole::Client#dump
             write `#{f.path}`
@@ -137,7 +137,7 @@ describe 'ridgepole' do
 
       expect(status.success?).to be_truthy
       expect(out).to match_fuzzy <<-MSG
-        Ridgepole::Client#initialize([#{conn_spec_str('ridgepole_test')}, {:dry_run=>false, :debug=>false, :color=>false}])
+        Ridgepole::Client#initialize([#{conn_spec_str('ridgepole_test')}, #{{ dry_run: false, debug: false, color: false }}])
         Apply `Schemafile`
         Ridgepole::Client#diff
         Ridgepole::Delta#differ?
@@ -158,7 +158,7 @@ describe 'ridgepole' do
 
         expect(status.success?).to be_truthy
         expect(out).to match_fuzzy <<-MSG
-          Ridgepole::Client#initialize([{"adapter"=>"mysql2", "database"=>"ridgepole_test_for_conf_file"}, {:dry_run=>false, :debug=>true, :color=>false}])
+          Ridgepole::Client#initialize([{"adapter"=>"mysql2", "database"=>"ridgepole_test_for_conf_file"}, #{{ dry_run: false, debug: true, color: false }}])
           Apply `Schemafile`
           Ridgepole::Client#diff
           Ridgepole::Delta#differ?
@@ -184,7 +184,7 @@ describe 'ridgepole' do
 
         expect(status.success?).to be_truthy
         expect(out).to match_fuzzy <<-MSG
-          Ridgepole::Client#initialize([{"adapter"=>"mysql2", "database"=>"ridgepole_development"}, {:dry_run=>false, :debug=>true, :color=>false}])
+          Ridgepole::Client#initialize([#{{ 'adapter' => 'mysql2', 'database' => 'ridgepole_development' }}, #{{ dry_run: false, debug: true, color: false }}])
           Apply `Schemafile`
           Ridgepole::Client#diff
           Ridgepole::Delta#differ?
@@ -201,7 +201,7 @@ describe 'ridgepole' do
 
           expect(status.success?).to be_truthy
           expect(out).to match_fuzzy <<-MSG
-            Ridgepole::Client#initialize([#{conn_spec_str('ridgepole_test')}, {:dry_run=>false, :debug=>false, :color=>false, :table_hash_options=>{:id=>:bigint, :unsigned=>true}}])
+            Ridgepole::Client#initialize([#{conn_spec_str('ridgepole_test')}, #{{ dry_run: false, debug: false, color: false, table_hash_options: { id: :bigint, unsigned: true } }}])
             Apply `Schemafile`
             Ridgepole::Client#diff
             Ridgepole::Delta#differ?
@@ -217,7 +217,7 @@ describe 'ridgepole' do
 
           expect(status.success?).to be_truthy
           expect(out).to match_fuzzy <<-MSG
-            Ridgepole::Client#initialize([#{conn_spec_str('ridgepole_test')}, {:dry_run=>false, :debug=>false, :color=>false, :table_hash_options=>{:id=>{:type=>:bigint, :unsigned=>true}}}])
+            Ridgepole::Client#initialize([#{conn_spec_str('ridgepole_test')}, #{{ dry_run: false, debug: false, color: false, table_hash_options: { id: { type: :bigint, unsigned: true } } }}])
             Apply `Schemafile`
             Ridgepole::Client#diff
             Ridgepole::Delta#differ?
@@ -233,7 +233,7 @@ describe 'ridgepole' do
 
       expect(status.success?).to be_truthy
       expect(out).to match_fuzzy <<-MSG
-        Ridgepole::Client#initialize([#{conn_spec_str('ridgepole_test')}, {:dry_run=>true, :debug=>false, :color=>false}])
+        Ridgepole::Client#initialize([#{conn_spec_str('ridgepole_test')}, #{{ dry_run: true, debug: false, color: false }}])
         Apply `Schemafile` (dry-run)
         Ridgepole::Client#diff
         Ridgepole::Delta#differ?
@@ -249,7 +249,7 @@ describe 'ridgepole' do
 
         expect(status.success?).to be_truthy
         expect(out).to match_fuzzy <<-MSG
-          Ridgepole::Client#initialize([#{conn_spec_str('ridgepole_test')}, {:dry_run=>false, :debug=>false, :color=>false}])
+          Ridgepole::Client#initialize([#{conn_spec_str('ridgepole_test')}, #{{ dry_run: false, debug: false, color: false }}])
           Apply `Schemafile`
           Ridgepole::Client#diff
           Ridgepole::Delta#differ?
@@ -262,7 +262,7 @@ describe 'ridgepole' do
 
         expect(status.success?).to be_truthy
         expect(out).to match_fuzzy <<-MSG
-          Ridgepole::Client#initialize([#{conn_spec_str('ridgepole_test')}, {:dry_run=>true, :debug=>false, :color=>false}])
+          Ridgepole::Client#initialize([#{conn_spec_str('ridgepole_test')}, #{{ dry_run: true, debug: false, color: false }}])
           Apply `Schemafile` (dry-run)
           Ridgepole::Client#diff
           Ridgepole::Delta#differ?
@@ -285,8 +285,8 @@ describe 'ridgepole' do
 
       expect(status.success?).to be_truthy
       expect(out).to match_fuzzy <<-MSG
-        Ridgepole::Client#initialize([#{conn_spec_str('ridgepole_test')}, {:dry_run=>false, :debug=>false, :color=>false}])
-        Ridgepole::Client.diff([#{conn_spec_str('ridgepole_test')}, #{conn_spec_str('ridgepole_test')}, {:dry_run=>false, :debug=>false, :color=>false}])
+        Ridgepole::Client#initialize([#{conn_spec_str('ridgepole_test')}, #{{ dry_run: false, debug: false, color: false }}])
+        Ridgepole::Client.diff([#{conn_spec_str('ridgepole_test')}, #{conn_spec_str('ridgepole_test')}, #{{ dry_run: false, debug: false, color: false }}])
         Ridgepole::Delta#differ?
       MSG
     end
@@ -301,8 +301,8 @@ describe 'ridgepole' do
         expect(status.success?).to be_falsey
 
         expect(out).to match_fuzzy <<-MSG
-          Ridgepole::Client#initialize([#{conn_spec_str('ridgepole_test')}, {:dry_run=>false, :debug=>false, :color=>false}])
-          Ridgepole::Client.diff([#{conn_spec_str('ridgepole_test')}, #{conn_spec_str('ridgepole_test')}, {:dry_run=>false, :debug=>false, :color=>false}])
+          Ridgepole::Client#initialize([#{conn_spec_str('ridgepole_test')}, #{{ dry_run: false, debug: false, color: false }}])
+          Ridgepole::Client.diff([#{conn_spec_str('ridgepole_test')}, #{conn_spec_str('ridgepole_test')}, #{{ dry_run: false, debug: false, color: false }}])
           Ridgepole::Delta#differ?
           Ridgepole::Delta#script
           Ridgepole::Delta#script
@@ -330,8 +330,8 @@ describe 'ridgepole' do
           expect(status.success?).to be_truthy
 
           expect(out).to match_fuzzy <<-MSG
-            Ridgepole::Client#initialize([#{conn_spec_str('ridgepole_test')}, {:dry_run=>false, :debug=>false, :color=>false}])
-            Ridgepole::Client.diff([{"adapter"=>"mysql2", "database"=>"ridgepole_test_for_conf_file"}, #{conn_spec_str('ridgepole_test')}, {:dry_run=>false, :debug=>false, :color=>false}])
+            Ridgepole::Client#initialize([#{conn_spec_str('ridgepole_test')}, #{{ dry_run: false, debug: false, color: false }}])
+            Ridgepole::Client.diff([{"adapter"=>"mysql2", "database"=>"ridgepole_test_for_conf_file"}, #{conn_spec_str('ridgepole_test')}, #{{ dry_run: false, debug: false, color: false }}])
             Ridgepole::Delta#differ?
           MSG
         end
@@ -350,8 +350,8 @@ describe 'ridgepole' do
           expect(status.success?).to be_truthy
 
           expect(out).to match_fuzzy <<-MSG
-            Ridgepole::Client#initialize([#{conn_spec_str('ridgepole_test')}, {:dry_run=>false, :debug=>false, :color=>false}])
-            Ridgepole::Client.diff([#{conn_spec_str('ridgepole_test')}, {"adapter"=>"mysql2", "database"=>"ridgepole_test_for_conf_file"}, {:dry_run=>false, :debug=>false, :color=>false}])
+            Ridgepole::Client#initialize([#{conn_spec_str('ridgepole_test')}, #{{ dry_run: false, debug: false, color: false }}])
+            Ridgepole::Client.diff([#{conn_spec_str('ridgepole_test')}, {"adapter"=>"mysql2", "database"=>"ridgepole_test_for_conf_file"}, #{{ dry_run: false, debug: false, color: false }}])
             Ridgepole::Delta#differ?
           MSG
         end
@@ -374,8 +374,8 @@ describe 'ridgepole' do
           expect(status.success?).to be_truthy
 
           expect(out).to match_fuzzy <<-MSG
-            Ridgepole::Client#initialize([#{conn_spec_str('ridgepole_test')}, {:dry_run=>false, :debug=>false, :color=>false}])
-            Ridgepole::Client.diff([{"adapter"=>"mysql2", "database"=>"ridgepole_development"}, #{conn_spec_str('ridgepole_test')}, {:dry_run=>false, :debug=>false, :color=>false}])
+            Ridgepole::Client#initialize([#{conn_spec_str('ridgepole_test')}, #{{ dry_run: false, debug: false, color: false }}])
+            Ridgepole::Client.diff([{"adapter"=>"mysql2", "database"=>"ridgepole_development"}, #{conn_spec_str('ridgepole_test')}, #{{ dry_run: false, debug: false, color: false }}])
             Ridgepole::Delta#differ?
           MSG
         end
@@ -398,8 +398,8 @@ describe 'ridgepole' do
           expect(status.success?).to be_truthy
 
           expect(out).to match_fuzzy <<-MSG
-            Ridgepole::Client#initialize([#{conn_spec_str('ridgepole_test')}, {:dry_run=>false, :debug=>false, :color=>false}])
-            Ridgepole::Client.diff([{"adapter"=>"mysql2", "database"=>"ridgepole_production"}, #{conn_spec_str('ridgepole_test')}, {:dry_run=>false, :debug=>false, :color=>false}])
+            Ridgepole::Client#initialize([#{conn_spec_str('ridgepole_test')}, #{{ dry_run: false, debug: false, color: false }}])
+            Ridgepole::Client.diff([{"adapter"=>"mysql2", "database"=>"ridgepole_production"}, #{conn_spec_str('ridgepole_test')}, #{{ dry_run: false, debug: false, color: false }}])
             Ridgepole::Delta#differ?
           MSG
         end
@@ -418,8 +418,8 @@ describe 'ridgepole' do
           expect(status.success?).to be_truthy
 
           expect(out).to match_fuzzy <<-MSG
-            Ridgepole::Client#initialize([#{conn_spec_str('ridgepole_test')}, {:dry_run=>false, :debug=>false, :color=>false}])
-            Ridgepole::Client.diff([{"adapter"=>"mysql2", "database"=>"ridgepole_test_for_conf_file"}, #{conn_spec_str('ridgepole_test')}, {:dry_run=>false, :debug=>false, :color=>false}])
+            Ridgepole::Client#initialize([#{conn_spec_str('ridgepole_test')}, #{{ dry_run: false, debug: false, color: false }}])
+            Ridgepole::Client.diff([{"adapter"=>"mysql2", "database"=>"ridgepole_test_for_conf_file"}, #{conn_spec_str('ridgepole_test')}, #{{ dry_run: false, debug: false, color: false }}])
             Ridgepole::Delta#differ?
           MSG
         end
@@ -438,8 +438,8 @@ describe 'ridgepole' do
           expect(status.success?).to be_truthy
 
           expect(out).to match_fuzzy <<-MSG
-            Ridgepole::Client#initialize([#{conn_spec_str('ridgepole_test')}, {:dry_run=>false, :debug=>false, :color=>false}])
-            Ridgepole::Client.diff([#{conf_file.path}, #{conn_spec_str('ridgepole_test')}, {:dry_run=>false, :debug=>false, :color=>false}])
+            Ridgepole::Client#initialize([#{conn_spec_str('ridgepole_test')}, #{{ dry_run: false, debug: false, color: false }}])
+            Ridgepole::Client.diff([#{conf_file.path}, #{conn_spec_str('ridgepole_test')}, #{{ dry_run: false, debug: false, color: false }}])
             Ridgepole::Delta#differ?
           MSG
         end

--- a/spec/mysql/diff/diff2_spec.rb
+++ b/spec/mysql/diff/diff2_spec.rb
@@ -172,10 +172,10 @@ describe 'Ridgepole::Client.diff' do
       delta = subject.diff(actual_dsl, expected_dsl)
       expect(delta.differ?).to be_truthy
       expect(delta.script).to match_ruby(<<-RUBY)
-        change_column("employee_clubs", "club_id", :integer, **{:unsigned=>false, :null=>true, :default=>nil, :comment=>nil})
+        change_column("employee_clubs", "club_id", :integer, **#{{ unsigned: false, null: true, default: nil, comment: nil }})
 
-        change_column("employees", "last_name", :string, **{:limit=>20, :default=>"XXX", :unsigned=>false, :comment=>nil})
-        change_column("employees", "gender", :string, **{:limit=>2, :null=>false, :default=>nil, :unsigned=>false, :comment=>nil})
+        change_column("employees", "last_name", :string, **#{{ limit: 20, default: 'XXX', unsigned: false, comment: nil }})
+        change_column("employees", "gender", :string, **#{{ limit: 2, null: false, default: nil, unsigned: false, comment: nil }})
       RUBY
     }
 

--- a/spec/mysql/diff/diff_spec.rb
+++ b/spec/mysql/diff/diff_spec.rb
@@ -146,10 +146,10 @@ describe 'Ridgepole::Client.diff' do
       delta = subject.diff(actual_dsl, expected_dsl)
       expect(delta.differ?).to be_truthy
       expect(delta.script).to match_ruby erbh(<<-ERB)
-        change_column("employee_clubs", "club_id", :integer, **{:unsigned=>false, :null=>true, :default=>nil, :comment=>nil})
+        change_column("employee_clubs", "club_id", :integer, **#{{ unsigned: false, null: true, default: nil, comment: nil }})
 
-        change_column("employees", "last_name", :string, **{:limit=>20, :default=>"XXX", :unsigned=>false, :comment=>nil})
-        change_column("employees", "gender", :string, **{:limit=>2, :null=>false, :default=>nil, :unsigned=>false, :comment=>nil})
+        change_column("employees", "last_name", :string, **#{{ limit: 20, default: 'XXX', unsigned: false, comment: nil }})
+        change_column("employees", "gender", :string, **#{{ limit: 2, null: false, default: nil, unsigned: false, comment: nil }})
       ERB
     }
   end

--- a/spec/mysql/fk/migrate_create_fk_spec.rb
+++ b/spec/mysql/fk/migrate_create_fk_spec.rb
@@ -36,7 +36,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
       expect(delta.differ?).to be_truthy
       expect(subject.dump).to match_ruby actual_dsl
       expect(delta.script).to match_fuzzy <<-RUBY
-        add_foreign_key("child", "parent", **{:name=>"child_ibfk_1"})
+        add_foreign_key("child", "parent", **#{{ name: 'child_ibfk_1' }})
       RUBY
       delta.migrate
       expect(subject.dump).to match_ruby expected_dsl
@@ -91,7 +91,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
       expect(delta.differ?).to be_truthy
       expect(subject.dump).to match_ruby actual_dsl
       expect(delta.script).to match_fuzzy <<-RUBY
-        add_foreign_key("child", "parent", **{:name=>"child_ibfk_1"})
+        add_foreign_key("child", "parent", **#{{ name: 'child_ibfk_1' }})
       RUBY
       delta.migrate
       expect(subject.dump).to match_ruby expected_dsl

--- a/spec/mysql/fk/migrate_fk_with_column_spec.rb
+++ b/spec/mysql/fk/migrate_fk_with_column_spec.rb
@@ -44,8 +44,8 @@ describe 'Ridgepole::Client#diff -> migrate' do
       expect(delta.differ?).to be_truthy
       expect(subject.dump).to match_ruby actual_dsl
       expect(delta.script).to match_fuzzy <<-RUBY
-        add_foreign_key("direct_messages", "users", **{:column=>"reciever_id"})
-        add_foreign_key("direct_messages", "users", **{:column=>"sender_id"})
+        add_foreign_key("direct_messages", "users", **#{{ column: 'reciever_id' }})
+        add_foreign_key("direct_messages", "users", **#{{ column: 'sender_id' }})
       RUBY
       delta.migrate
       expect(subject.dump).to match_ruby expected_dsl

--- a/spec/mysql/migrate/migrate_add_column_spec.rb
+++ b/spec/mysql/migrate/migrate_add_column_spec.rb
@@ -146,12 +146,12 @@ describe 'Ridgepole::Client#diff -> migrate' do
       expect(subject.dump).to match_ruby actual_dsl
       expect(delta.script).to match_fuzzy erbh(<<-ERB)
         change_table("employee_clubs", bulk: true) do |t|
-          t.column("any_col", :string, **{:null=>false, :after=>"club_id", :limit=>255})
+          t.column("any_col", :string, **#{{ null: false, after: 'club_id', limit: 255 }})
         end
 
         change_table("employees", bulk: true) do |t|
-          t.column("age", :integer, **{:null=>false, :after=>"hire_date", :limit=>4})
-          t.column("updated_at", :date, **{:after=>"age"})
+          t.column("age", :integer, **#{{ null: false, after: 'hire_date', limit: 4 }})
+          t.column("updated_at", :date, **#{{ after: 'age' }})
         end
       ERB
       delta.migrate

--- a/spec/mysql/migrate/migrate_change_column_spec.rb
+++ b/spec/mysql/migrate/migrate_change_column_spec.rb
@@ -143,12 +143,12 @@ describe 'Ridgepole::Client#diff -> migrate' do
       expect(subject.dump).to match_ruby actual_dsl
       expect(delta.script).to match_fuzzy erbh(<<-ERB)
         change_table("employee_clubs", bulk: true) do |t|
-          t.change("club_id", :integer, **{:null=>true, :default=>nil, :unsigned=>false, :comment=>nil})
+          t.change("club_id", :integer, **#{{ null: true, default: nil, unsigned: false, comment: nil }})
         end
 
         change_table("employees", bulk: true) do |t|
-          t.change("last_name", :string, **{:limit=>20, :default=>"XXX", :unsigned=>false, :comment=>nil})
-          t.change("gender", :string, **{:limit=>2, :null=>false, :default=>nil, :unsigned=>false, :comment=>nil})
+          t.change("last_name", :string, **#{{ limit: 20, default: 'XXX', unsigned: false, comment: nil }})
+          t.change("gender", :string, **#{{ limit: 2, null: false, default: nil, unsigned: false, comment: nil }})
         end
       ERB
       delta.migrate

--- a/spec/mysql/migrate/migrate_change_index_spec.rb
+++ b/spec/mysql/migrate/migrate_change_index_spec.rb
@@ -206,17 +206,17 @@ describe 'Ridgepole::Client#diff -> migrate' do
       expect(delta.script).to match_fuzzy <<-RUBY
         change_table("dept_emp", bulk: true) do |t|
           t.remove_index(name: "emp_no")
-          t.index(["from_date"], **{:name=>"emp_no", :using=>:btree, :unique=>false})
+          t.index(["from_date"], **#{{ name: 'emp_no', using: :btree, unique: false }})
         end
 
         change_table("dept_manager", bulk: true) do |t|
           t.remove_index(name: "emp_no")
-          t.index(["from_date"], **{:name=>"emp_no", :using=>:btree, :unique=>false})
+          t.index(["from_date"], **#{{ name: 'emp_no', using: :btree, unique: false }})
         end
 
         change_table("salaries", bulk: true) do |t|
           t.remove_index(name: "emp_no")
-          t.index(["from_date"], **{:name=>"emp_no", :using=>:btree, :unique=>false})
+          t.index(["from_date"], **#{{ name: 'emp_no', using: :btree, unique: false }})
         end
       RUBY
     }

--- a/spec/mysql/migrate/migrate_change_table_comment_spec.rb
+++ b/spec/mysql/migrate/migrate_change_table_comment_spec.rb
@@ -40,13 +40,13 @@ describe 'Ridgepole::Client#diff -> migrate' do
       allow(Ridgepole::Logger.instance).to receive(:verbose_info)
       expect(Ridgepole::Logger.instance).to receive(:verbose_info).with(<<-MSG)
 # Table option changes are ignored on `employees`.
-  from: {:comment=>"old comment"}
-    to: {:comment=>"new comment"}
+  from: #{{ comment: 'old comment' }}
+    to: #{{ comment: 'new comment' }}
       MSG
       expect(Ridgepole::Logger.instance).to receive(:verbose_info).once.with(<<-MSG)
 # Table option changes are ignored on `tenants`.
-  from: {:comment=>"old comment '"}
-    to: {:comment=>"new comment '"}
+  from: #{{ comment: "old comment '" }}
+    to: #{{ comment: "new comment '" }}
       MSG
       delta = subject.diff(expected_dsl)
       expect(delta.differ?).to be_falsey

--- a/spec/mysql/migrate/migrate_change_table_option_spec.rb
+++ b/spec/mysql/migrate/migrate_change_table_option_spec.rb
@@ -33,8 +33,8 @@ describe 'Ridgepole::Client#diff -> migrate' do
       allow(Ridgepole::Logger.instance).to receive(:verbose_info)
       expect(Ridgepole::Logger.instance).to receive(:verbose_info).with(<<-MSG)
 # Table option changes are ignored on `employees`.
-  from: {:primary_key=>"emp_no"}
-    to: {:primary_key=>"emp_no2"}
+  from: #{{ primary_key: 'emp_no' }}
+    to: #{{ primary_key: 'emp_no2' }}
       MSG
       delta = subject.diff(expected_dsl)
       expect(delta.differ?).to be_falsey

--- a/spec/mysql/migrate/migrate_check_relation_column_type_spec.rb
+++ b/spec/mysql/migrate/migrate_check_relation_column_type_spec.rb
@@ -47,8 +47,8 @@ describe 'Ridgepole::Client#diff -> migrate' do
     it {
       expect(Ridgepole::Logger.instance).to receive(:warn).with(<<-MSG)
 [WARNING] Relation column type is different.
-              employees.id: {:type=>:bigint}
-  dept_manager.employee_id: {:type=>:integer}
+              employees.id: #{{ type: :bigint }}
+  dept_manager.employee_id: #{{ type: :integer }}
       MSG
 
       delta = subject.diff(expected_dsl)
@@ -105,8 +105,8 @@ describe 'Ridgepole::Client#diff -> migrate' do
     it {
       expect(Ridgepole::Logger.instance).to receive(:warn).with(<<-MSG)
 [WARNING] Relation column type is different.
-              employees.id: {:type=>:bigint, :unsigned=>true}
-  dept_manager.employee_id: {:type=>:bigint}
+              employees.id: #{{ type: :bigint, unsigned: true }}
+  dept_manager.employee_id: #{{ type: :bigint }}
       MSG
 
       delta = subject.diff(expected_dsl)

--- a/spec/mysql/migrate/migrate_create_index_spec.rb
+++ b/spec/mysql/migrate/migrate_create_index_spec.rb
@@ -142,15 +142,15 @@ describe 'Ridgepole::Client#diff -> migrate' do
       expect(subject.dump).to match_ruby actual_dsl
       expect(delta.script).to match_fuzzy erbh(<<-ERB)
         change_table("clubs", bulk: true) do |t|
-          t.index(["name"], **{:name=>"idx_name", :unique=>true})
+          t.index(["name"], **#{{ name: 'idx_name', unique: true }})
         end
 
         change_table("employee_clubs", bulk: true) do |t|
-          t.index(["emp_no", "club_id"], **{:name=>"idx_emp_no_club_id"})
+          t.index(["emp_no", "club_id"], **#{{ name: 'idx_emp_no_club_id' }})
         end
 
         change_table("titles", bulk: true) do |t|
-          t.index(["emp_no"], **{:name=>"emp_no"})
+          t.index(["emp_no"], **#{{ name: 'emp_no' }})
         end
       ERB
       delta.migrate

--- a/spec/mysql/migrate/migrate_create_table_with_index_spec.rb
+++ b/spec/mysql/migrate/migrate_create_table_with_index_spec.rb
@@ -25,13 +25,13 @@ describe 'Ridgepole::Client#diff -> migrate (with index)' do
       expect(delta.differ?).to be_truthy
 
       expect(delta.script).to match_fuzzy erbh(<<-ERB)
-        create_table("dept_emp", **{:primary_key=>["emp_no", "dept_no"]}) do |t|
-          t.column("emp_no", :"integer", **{:null=>false, :limit=>4})
-          t.column("dept_no", :"string", **{:null=>false, :limit=>255})
-          t.column("from_date", :"date", **{:null=>false})
-          t.column("to_date", :"date", **{:null=>false})
-          t.index(["dept_no"], **{:name=>"dept_no"})
-          t.index(["emp_no"], **{:name=>"emp_no"})
+        create_table("dept_emp", **#{{ primary_key: %w[emp_no dept_no] }}) do |t|
+          t.column("emp_no", :"integer", **#{{ null: false, limit: 4 }})
+          t.column("dept_no", :"string", **#{{ null: false, limit: 255 }})
+          t.column("from_date", :"date", **#{{ null: false }})
+          t.column("to_date", :"date", **#{{ null: false }})
+          t.index(["dept_no"], **#{{ name: 'dept_no' }})
+          t.index(["emp_no"], **#{{ name: 'emp_no' }})
         end
       ERB
 

--- a/spec/mysql/migrate/migrate_create_table_with_options_spec.rb
+++ b/spec/mysql/migrate/migrate_create_table_with_options_spec.rb
@@ -20,11 +20,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
       expect(delta.differ?).to be_truthy
 
       expect(delta.script).to match_fuzzy <<-RUBY
-        create_table("employee_clubs", **{:options=>"ENGINE=MyISAM CHARSET=utf8"}) do |t|
-          t.column("emp_no", :"integer", **{:null=>false, :unsigned=>true, :limit=>4})
-          t.column("club_id", :"integer", **{:null=>false, :unsigned=>true, :limit=>4})
+        create_table("employee_clubs", **#{{ options: 'ENGINE=MyISAM CHARSET=utf8' }}) do |t|
+          t.column("emp_no", :"integer", **#{{ null: false, unsigned: true, limit: 4 }})
+          t.column("club_id", :"integer", **#{{ null: false, unsigned: true, limit: 4 }})
         end
-        add_index("employee_clubs", ["emp_no", "club_id"], **{:name=>"idx_emp_no_club_id", :using=>:btree})
+        add_index("employee_clubs", ["emp_no", "club_id"], **#{{ name: 'idx_emp_no_club_id', using: :btree }})
       RUBY
     }
   end
@@ -48,11 +48,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
       expect(delta.differ?).to be_truthy
 
       expect(delta.script).to match_fuzzy <<-RUBY
-        create_table("employee_clubs", **{:options=>"ENGINE=InnoDB CHARSET=utf8mb4"}) do |t|
-          t.column("emp_no", :"integer", **{:null=>false, :unsigned=>true, :limit=>4})
-          t.column("club_id", :"integer", **{:null=>false, :unsigned=>true, :limit=>4})
+        create_table("employee_clubs", **#{{ options: 'ENGINE=InnoDB CHARSET=utf8mb4' }}) do |t|
+          t.column("emp_no", :"integer", **#{{ null: false, unsigned: true, limit: 4 }})
+          t.column("club_id", :"integer", **#{{ null: false, unsigned: true, limit: 4 }})
         end
-        add_index("employee_clubs", ["emp_no", "club_id"], **{:name=>"idx_emp_no_club_id", :using=>:btree})
+        add_index("employee_clubs", ["emp_no", "club_id"], **#{{ name: 'idx_emp_no_club_id', using: :btree }})
       RUBY
     }
   end

--- a/spec/mysql/migrate/migrate_primary_key_spec.rb
+++ b/spec/mysql/migrate/migrate_primary_key_spec.rb
@@ -25,8 +25,8 @@ describe 'Ridgepole::Client#diff -> migrate' do
       it {
         expect(Ridgepole::Logger.instance).to receive(:warn).with(erbh(<<-ERB))
 [WARNING] Primary key definition of `employees` differ but `allow_pk_change` option is false
-  from: {:id=>{:type=>:integer, :unsigned=>true}}
-    to: {:id=>:bigint, :unsigned=>true}
+  from: #{{ id: { type: :integer, unsigned: true } }}
+    to: #{{ id: :bigint, unsigned: true }}
         ERB
 
         delta = subject.diff(expected_dsl)

--- a/spec/mysql/migrate/migrate_script_error_spec.rb
+++ b/spec/mysql/migrate/migrate_script_error_spec.rb
@@ -80,7 +80,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
       expect(subject.dump).to match_ruby actual_dsl
 
       errmsg = Regexp.new(Regexp.escape(<<-MSG.strip))
-        33: add_index("employee_clubs", ["emp_no", "Xclub_id"], **{:name=>"idx_emp_no_club_id", :using=>:btree})
+        33: add_index("employee_clubs", ["emp_no", "Xclub_id"], **#{{ name: 'idx_emp_no_club_id', using: :btree }})
       MSG
 
       expect do

--- a/spec/mysql/~default_name_fk/migrate_create_fk_spec.rb
+++ b/spec/mysql/~default_name_fk/migrate_create_fk_spec.rb
@@ -36,7 +36,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
       expect(delta.differ?).to be_truthy
       expect(subject.dump).to match_ruby actual_dsl
       expect(delta.script).to match_fuzzy <<-RUBY
-        add_foreign_key("child", "parent", **{:name=>"fk_rails_e74ce85cbc"})
+        add_foreign_key("child", "parent", **#{{ name: 'fk_rails_e74ce85cbc' }})
       RUBY
       delta.migrate
       expect(subject.dump).to match_ruby expected_dsl

--- a/spec/mysql/~dump_auto_increment/migrate_create_table_with_index_spec.rb
+++ b/spec/mysql/~dump_auto_increment/migrate_create_table_with_index_spec.rb
@@ -25,13 +25,13 @@ describe 'Ridgepole::Client#diff -> migrate (with index)' do
       expect(delta.differ?).to be_truthy
 
       expect(delta.script).to match_fuzzy erbh(<<-ERB)
-        create_table("dept_emp", **{:primary_key=>["emp_no", "dept_no"]}) do |t|
-          t.column("emp_no", :"integer", **{:null=>false, :limit=>4})
-          t.column("dept_no", :"integer", **{:null=>false, :auto_increment=>true, :limit=>4})
-          t.column("from_date", :"date", **{:null=>false})
-          t.column("to_date", :"date", **{:null=>false})
-          t.index(["dept_no"], **{:name=>"dept_no"})
-          t.index(["emp_no"], **{:name=>"emp_no"})
+        create_table("dept_emp", **#{{ primary_key: %w[emp_no dept_no] }}) do |t|
+          t.column("emp_no", :"integer", **#{{ null: false, limit: 4 }})
+          t.column("dept_no", :"integer", **#{{ null: false, auto_increment: true, limit: 4 }})
+          t.column("from_date", :"date", **#{{ null: false }})
+          t.column("to_date", :"date", **#{{ null: false }})
+          t.index(["dept_no"], **#{{ name: 'dept_no' }})
+          t.index(["emp_no"], **#{{ name: 'emp_no' }})
         end
       ERB
 

--- a/spec/postgresql/diff/diff_spec.rb
+++ b/spec/postgresql/diff/diff_spec.rb
@@ -148,9 +148,9 @@ describe 'Ridgepole::Client.diff' do
       delta = subject.diff(actual_dsl, expected_dsl)
       expect(delta.differ?).to be_truthy
       expect(delta.script).to match_fuzzy <<-RUBY
-        change_column("employee_clubs", "club_id", :integer, **{:null=>true, :default=>nil})
+        change_column("employee_clubs", "club_id", :integer, **#{{ null: true, default: nil }})
 
-        change_column("employees", "last_name", :string, **{:limit=>20, :default=>"XXX"})
+        change_column("employees", "last_name", :string, **#{{ limit: 20, default: 'XXX' }})
       RUBY
     }
   end

--- a/spec/postgresql/fk/migrate_create_fk_spec.rb
+++ b/spec/postgresql/fk/migrate_create_fk_spec.rb
@@ -36,7 +36,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
       expect(delta.differ?).to be_truthy
       expect(subject.dump).to match_ruby actual_dsl
       expect(delta.script).to match_fuzzy <<-RUBY
-        add_foreign_key("child", "parent", **{:name=>"child_ibfk_1"})
+        add_foreign_key("child", "parent", **#{{ name: 'child_ibfk_1' }})
       RUBY
       delta.migrate
       expect(subject.dump).to match_ruby expected_dsl

--- a/spec/postgresql/migrate/migrate_add_column_spec.rb
+++ b/spec/postgresql/migrate/migrate_add_column_spec.rb
@@ -144,17 +144,17 @@ describe 'Ridgepole::Client#diff -> migrate' do
       expect(subject.dump).to match_ruby actual_dsl
       expect(delta.script).to match_fuzzy <<-RUBY
         change_table("employee_clubs", bulk: true) do |t|
-          t.column("any_col", :string, **{:limit=>255, :null=>false})
+          t.column("any_col", :string, **#{{ limit: 255, null: false }})
         end
 
         change_table("employees", bulk: true) do |t|
-          t.column("age", :integer, **{:null=>false})
+          t.column("age", :integer, **#{{ null: false }})
           t.column("updated_at", :date, **{})
         end
 
         change_table("titles", bulk: true) do |t|
-          t.column("title_no", :serial, **{:null=>false})
-          t.column("title_bigno", :bigserial, **{:null=>false})
+          t.column("title_no", :serial, **#{{ null: false }})
+          t.column("title_bigno", :bigserial, **#{{ null: false }})
         end
       RUBY
       delta.migrate

--- a/spec/postgresql/migrate/migrate_change_column_spec.rb
+++ b/spec/postgresql/migrate/migrate_change_column_spec.rb
@@ -139,11 +139,11 @@ describe 'Ridgepole::Client#diff -> migrate' do
       expect(subject.dump).to match_ruby actual_dsl
       expect(delta.script).to match_fuzzy <<-RUBY
         change_table("employee_clubs", bulk: true) do |t|
-          t.change("club_id", :integer, **{:null=>true, :default=>nil})
+          t.change("club_id", :integer, **#{{ null: true, default: nil }})
         end
 
         change_table("employees", bulk: true) do |t|
-          t.change("last_name", :string, **{:limit=>20, :default=>"XXX"})
+          t.change("last_name", :string, **#{{ limit: 20, default: 'XXX' }})
         end
       RUBY
       delta.migrate

--- a/spec/postgresql/migrate/migrate_change_index_spec.rb
+++ b/spec/postgresql/migrate/migrate_change_index_spec.rb
@@ -142,17 +142,17 @@ describe 'Ridgepole::Client#diff -> migrate' do
       expect(delta.script).to match_fuzzy <<-RUBY
         change_table("dept_emp", bulk: true) do |t|
           t.remove_index(name: "idx_dept_emp_emp_no")
-          t.index(["from_date"], **{:name=>"idx_dept_emp_emp_no", :using=>:btree, :unique=>false})
+          t.index(["from_date"], **#{{ name: 'idx_dept_emp_emp_no', using: :btree, unique: false }})
         end
 
         change_table("dept_manager", bulk: true) do |t|
           t.remove_index(name: "idx_dept_manager_emp_no")
-          t.index(["from_date"], **{:name=>"idx_dept_manager_emp_no", :using=>:btree, :unique=>false})
+          t.index(["from_date"], **#{{ name: 'idx_dept_manager_emp_no', using: :btree, unique: false }})
         end
 
         change_table("salaries", bulk: true) do |t|
           t.remove_index(name: "idx_salaries_emp_no")
-          t.index(["from_date"], **{:name=>"idx_salaries_emp_no", :using=>:btree, :unique=>false})
+          t.index(["from_date"], **#{{ name: 'idx_salaries_emp_no', using: :btree, unique: false }})
         end
       RUBY
 

--- a/spec/postgresql/migrate/migrate_check_relation_column_type_spec.rb
+++ b/spec/postgresql/migrate/migrate_check_relation_column_type_spec.rb
@@ -47,8 +47,8 @@ describe 'Ridgepole::Client#diff -> migrate' do
     it {
       expect(Ridgepole::Logger.instance).to receive(:warn).with(<<-MSG)
 [WARNING] Relation column type is different.
-              employees.id: {:type=>:integer}
-  dept_manager.employee_id: {:type=>:bigint}
+              employees.id: #{{ type: :integer }}
+  dept_manager.employee_id: #{{ type: :bigint }}
       MSG
 
       delta = subject.diff(expected_dsl)

--- a/spec/postgresql/migrate/migrate_create_table_with_default_proc_spec.rb
+++ b/spec/postgresql/migrate/migrate_create_table_with_default_proc_spec.rb
@@ -85,8 +85,8 @@ describe 'Ridgepole::Client#diff -> migrate' do
       it {
         expect(Ridgepole::Logger.instance).to receive(:warn).with(<<-MSG)
 [WARNING] Primary key definition of `users` differ but `allow_pk_change` option is false
-  from: {:id=>:uuid, :default=>"uuid_generate_v1()"}
-    to: {:id=>:uuid, :default=>"uuid_generate_v4()"}
+  from: #{{ id: :uuid, default: 'uuid_generate_v1()' }}
+    to: #{{ id: :uuid, default: 'uuid_generate_v4()' }}
         MSG
 
         delta = subject.diff(expected_dsl)

--- a/spec/postgresql/migrate/migrate_drop_column_with_index_spec.rb
+++ b/spec/postgresql/migrate/migrate_drop_column_with_index_spec.rb
@@ -151,7 +151,7 @@ end
 
 change_table("employee_clubs", bulk: true) do |t|
   t.remove("club_id")
-  t.index(["emp_no"], **{:name=>"idx_employee_clubs_emp_no"})
+  t.index(["emp_no"], **#{{ name: 'idx_employee_clubs_emp_no' }})
 end
 
 change_table("employees", bulk: true) do |t|

--- a/spec/postgresql/migrate/migrate_primary_key2_spec.rb
+++ b/spec/postgresql/migrate/migrate_primary_key2_spec.rb
@@ -30,8 +30,8 @@ describe 'Ridgepole::Client#diff -> migrate' do
       it {
         expect(Ridgepole::Logger.instance).to receive(:warn).with(<<-MSG)
 [WARNING] Primary key definition of `employees` differ but `allow_pk_change` option is false
-  from: {:id=>false}
-    to: {:id=>:bigint}
+  from: #{{ id: false }}
+    to: #{{ id: :bigint }}
         MSG
 
         delta = subject.diff(expected_dsl)

--- a/spec/postgresql/migrate/migrate_primary_key_spec.rb
+++ b/spec/postgresql/migrate/migrate_primary_key_spec.rb
@@ -28,8 +28,8 @@ describe 'Ridgepole::Client#diff -> migrate' do
       it {
         expect(Ridgepole::Logger.instance).to receive(:warn).with(<<-MSG)
 [WARNING] Primary key definition of `employees` differ but `allow_pk_change` option is false
-  from: {:id=>:serial}
-    to: {:id=>:bigint}
+  from: #{{ id: :serial }}
+    to: #{{ id: :bigint }}
         MSG
 
         delta = subject.diff(expected_dsl)

--- a/spec/postgresql/~default_name_fk/migrate_create_fk_spec.rb
+++ b/spec/postgresql/~default_name_fk/migrate_create_fk_spec.rb
@@ -36,7 +36,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
       expect(delta.differ?).to be_truthy
       expect(subject.dump).to match_ruby actual_dsl
       expect(delta.script).to match_fuzzy <<-RUBY
-        add_foreign_key("child", "parent", **{:name=>"fk_rails_e74ce85cbc"})
+        add_foreign_key("child", "parent", **#{{ name: 'fk_rails_e74ce85cbc' }})
       RUBY
       delta.migrate
       expect(subject.dump).to match_ruby expected_dsl


### PR DESCRIPTION
This PR adds Ruby 3.4 to the CI matrix to confirm Ridgepole works with Ruby 3.4.

In Ruby 3.4,  the result of `Hash.inspect` has changed. So I updated some specs to wrap hash with `#{}` to work both 3.4 and older.
Ref: https://bugs.ruby-lang.org/issues/20433