### PR TITLE
Support composite foreign key for non-primary key

### DIFF
--- a/lib/ridgepole/dsl_parser.rb
+++ b/lib/ridgepole/dsl_parser.rb
@@ -36,13 +36,21 @@ module Ridgepole
 
       attrs[:foreign_keys].each_value do |foreign_key_attrs|
         fk_index = foreign_key_attrs[:options][:column] || "#{foreign_key_attrs[:to_table].singularize}_id"
-        next if attrs[:indices]&.any? { |_k, v| v[:column_name].first == fk_index }
-        # NOTE: For composite primary keys, the first column of the primary key is used as the foreign key index
-        next if Array(attrs[:options][:primary_key]).first == fk_index
+        next if attrs[:indices]&.any? { |_, v| match_column_name?(v[:column_name], fk_index) }
+        next if match_column_name?(attrs[:options][:primary_key], fk_index)
 
         raise("The column `#{fk_index}` of the table `#{table_name}` has a foreign key but no index. " \
               'Although InnoDB creates an index automatically, ' \
               'please add one explicitly in order for ridgepole to manage it.')
+      end
+    end
+
+    def match_column_name?(index_column_name, fk_index)
+      if fk_index.is_a?(Array)
+        index_column_name == fk_index
+      else
+        # NOTE: For composite primary keys, the first column of the primary key is used as the foreign key index
+        Array(index_column_name).first == fk_index
       end
     end
   end

--- a/lib/ridgepole/dsl_parser/context.rb
+++ b/lib/ridgepole/dsl_parser/context.rb
@@ -77,8 +77,16 @@ module Ridgepole
         from_table = from_table.to_s
         to_table = to_table.to_s
         options[:name] = options[:name].to_s if options[:name]
-        options[:primary_key] = options[:primary_key].to_s if options[:primary_key]
-        options[:column] = options[:column].to_s if options[:column]
+        if options[:primary_key].is_a?(Array)
+          options[:primary_key] = options[:primary_key].map(&:to_s)
+        elsif options[:primary_key]
+          options[:primary_key] = options[:primary_key].to_s
+        end
+        if options[:column].is_a?(Array)
+          options[:column] = options[:column].map(&:to_s)
+        elsif options[:column]
+          options[:column] = options[:column].to_s
+        end
         @__definition[from_table] ||= {}
         @__definition[from_table][:foreign_keys] ||= {}
         idx = options[:name] || [from_table, to_table, options[:column]]


### PR DESCRIPTION
Current composite key support is insufficient.
I couldn't create a composite foreign key for a non-primary key.

schema example:
```ruby
add_index "table_a", ["column_a", "column_b"]
add_foreign_key "table_a", "table_b", column: ["column_a", "column_b"], primary_key: ["column_a", "column_b"]
```

The error message is the following.
```
[ERROR] The column `["column_a", "column_b"]` of the table `table_a` has a foreign key but no index. Although InnoDB creates an index automatically, please add one explicitly in order for ridgepole to manage it.
        /home/joker/repro/repro.rails/vendor/bundle/ruby/3.0.0/gems/ridgepole-3.0.0/lib/ridgepole/dsl_parser.rb:43:in `block in check_foreign_key_without_index'
```



I fixed Array key handling.