### PR TITLE
chore: Fix pulls#512: Use String#delete

### DIFF
--- a/lib/ridgepole/diff.rb
+++ b/lib/ridgepole/diff.rb
@@ -3,7 +3,7 @@
 module Ridgepole
   class Diff
     PRIMARY_KEY_OPTIONS = %i[id limit default null precision scale collation unsigned].freeze
-    REGEX_COLUMN_IDENTIFIER_QUOTATION_CHARS = /["`]/.freeze
+    REGEX_COLUMN_IDENTIFIER_QUOTATION_CHARS = '"`'
 
     def initialize(options = {})
       @options = options
@@ -512,7 +512,7 @@ module Ridgepole
 
     def normalize_check_constraint(attr)
       attr = attr.dup
-      attr[:expression] = attr[:expression].gsub(REGEX_COLUMN_IDENTIFIER_QUOTATION_CHARS, '')
+      attr[:expression] = attr[:expression].delete(REGEX_COLUMN_IDENTIFIER_QUOTATION_CHARS)
       attr
     end
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
It would be helpful if you could clarify the problem by creating an issue first.
-->

- fix https://github.com/ridgepole/ridgepole/pull/512

Use `String#delete` instead of `String#gsub`.