### PR TITLE
 Fix unnecessary index recreation due to algorithm option

### DIFF
--- a/lib/ridgepole/diff.rb
+++ b/lib/ridgepole/diff.rb
@@ -353,11 +353,7 @@ module Ridgepole
           normalize_index_options!(from_attrs[:options])
           normalize_index_options!(to_attrs[:options])
 
-          # Create copies for comparison, excluding algorithm option
-          to_attrs_for_compare = to_attrs.deep_dup
-          to_attrs_for_compare[:options]&.delete(:algorithm)
-
-          if from_attrs != to_attrs_for_compare
+          if from_attrs != to_attrs
             indices_delta[:add] ||= {}
             indices_delta[:add][index_name] = to_attrs
 
@@ -437,6 +433,9 @@ module Ridgepole
       # XXX: MySQL only?
       opts[:using] = :btree unless opts.key?(:using)
       opts[:unique] = false unless opts.key?(:unique)
+
+      # 'algorithm: concurrently' is required for index creation but not stored in PostgreSQL DB metadata, so remove 'algorithm' to prevent diff
+      opts.delete(:algorithm)
     end
 
     def columns_all_include?(expected_columns, actual_columns, table_options)

--- a/lib/ridgepole/diff.rb
+++ b/lib/ridgepole/diff.rb
@@ -355,7 +355,7 @@ module Ridgepole
 
           # Create copies for comparison, excluding algorithm option
           to_attrs_for_compare = to_attrs.deep_dup
-          to_attrs_for_compare[:options].delete(:algorithm) if to_attrs_for_compare[:options]
+          to_attrs_for_compare[:options]&.delete(:algorithm)
 
           if from_attrs != to_attrs_for_compare
             indices_delta[:add] ||= {}

--- a/lib/ridgepole/diff.rb
+++ b/lib/ridgepole/diff.rb
@@ -353,7 +353,11 @@ module Ridgepole
           normalize_index_options!(from_attrs[:options])
           normalize_index_options!(to_attrs[:options])
 
-          if from_attrs != to_attrs
+          # Create copies for comparison, excluding algorithm option
+          to_attrs_for_compare = to_attrs.deep_dup
+          to_attrs_for_compare[:options].delete(:algorithm) if to_attrs_for_compare[:options]
+
+          if from_attrs != to_attrs_for_compare
             indices_delta[:add] ||= {}
             indices_delta[:add][index_name] = to_attrs
 

--- a/spec/postgresql/diff/diff_spec.rb
+++ b/spec/postgresql/diff/diff_spec.rb
@@ -241,7 +241,7 @@ describe 'Ridgepole::Client.diff' do
       it 'creates index with algorithm: :concurrently' do
         delta = subject.diff(actual_dsl, expected_dsl)
         expect(delta).to be_differ
-        expect(delta.script).to include('add_index("users", ["email"], **{:name=>"idx_users_email", :algorithm=>:concurrently})')
+        expect(delta.script).to match(/add_index\("users", \["email"\], .*algorithm.*concurrently.*\)/)
       end
     end
     context 'when index exists without algorithm' do

--- a/spec/postgresql/diff/diff_spec.rb
+++ b/spec/postgresql/diff/diff_spec.rb
@@ -241,7 +241,9 @@ describe 'Ridgepole::Client.diff' do
       it 'creates index with algorithm: :concurrently' do
         delta = subject.diff(actual_dsl, expected_dsl)
         expect(delta).to be_differ
-        expect(delta.script).to match(/add_index\("users", \["email"\], .*algorithm.*concurrently.*\)/)
+        expect(delta.script).to match_ruby(<<-RUBY)
+          add_index("users", ["email"], **{name: "idx_users_email", algorithm: :concurrently})
+        RUBY
       end
     end
     context 'when index exists without algorithm' do


### PR DESCRIPTION
This PR fixes #554 where indexes with `algorithm: :concurrently` cause constant DROP/CREATE operations on every ridgepole run.

## Problem

The `algorithm: :concurrently` option is used only during index creation and is not stored in the database metadata. This caused ridgepole to detect false differences between the schema file and the actual database state.

## Solution

Modified the index comparison logic in `scan_indices_change` to exclude the `algorithm` option when comparing index definitions. The option is still preserved in the generated migration scripts to ensure `CREATE INDEX CONCURRENTLY` is used when creating new indexes.

## Changes

- Modified `lib/ridgepole/diff.rb` to ignore `algorithm` option during comparison
- Added test cases to verify the fix works correctly

## Testing

Added two test cases:
1. Verify that new indexes with `algorithm: :concurrently` are created correctly
2. Verify that existing indexes are not recreated when only the `algorithm` option differs

Run tests with:
```console
POSTGRESQL=1 bundle exec rspec spec/postgresql/diff/diff_spec.rb
```

in [cfd9e7b](https://github.com/ridgepole/ridgepole/pull/555/commits/cfd9e7b4898eab7a77ccabb073c41b89365964b8)
```console
$ POSTGRESQL=1 DEBUG=1 bundle exec rspec spec/postgresql/diff/diff_spec.rb
....F

Failures:

  1) Ridgepole::Client.diff when add index with algorithm: :concurrently when index exists without algorithm recreates index with algorithm: :concurrently
     Failure/Error: expect(delta).to_not be_differ
       expected `#<Ridgepole::Delta:0x0000000125411470 @delta={:change=>{"users"=>{:indices=>{:add=>{"idx_users_email"...alse, @mon_data=#<Monitor:0x000000011eb9cc78>, @mon_data_owner_object_id=4940>, @level_override={}>>.differ?` to be falsey, got true
     # ./spec/postgresql/diff/diff_spec.rb:272:in `block (4 levels) in <top (required)>'

Finished in 2.67 seconds (files took 0.48748 seconds to load)
5 examples, 1 failure

Failed examples:

rspec ./spec/postgresql/diff/diff_spec.rb:270 # Ridgepole::Client.diff when add index with algorithm: :concurrently when index exists without algorithm recreates index with algorithm: :concurrently
```