### PR TITLE
chore(gemspec): exclude unnecessary files from gem package

### DIFF
--- a/ridgepole.gemspec
+++ b/ridgepole.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |spec|
   spec.platform      = Gem::Platform::RUBY
 
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
-    `git ls-files -z`.split("\x0").reject do |f|
-      f.match(%r{\A(?:(?:test|spec|features)/|\.(?:git|travis|circleci)|appveyor)})
+    `git ls-files -z`.split("\x0").select do |f|
+      f.match(%r{\A(lib|bin)/}) || %w[README.md LICENSE.txt CHANGELOG.md].include?(f)
     end
   end
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }


### PR DESCRIPTION
## Problem

The current gemspec includes unnecessary development files (Appraisals, Gemfile, compose.yaml, gemfiles/, etc.) in the gem package.

## Solution

Simplified `spec.files` to explicitly include only essential files using `Dir.glob('lib/**/*') + Dir.glob('bin/*') + %w[README.md LICENSE.txt CHANGELOG.md]`.