### PR TITLE
Remove debug print in a spec

### DIFF
--- a/spec/mysql/migrate/migrate_change_column_comment_spec.rb
+++ b/spec/mysql/migrate/migrate_change_column_comment_spec.rb
@@ -40,7 +40,6 @@ describe 'Ridgepole::Client#diff -> migrate' do
       ERB
 
       delta.migrate
-      puts subject.dump
       expect(subject.dump).to match_ruby expected_dsl
     }
   end

--- a/spec/postgresql/migrate/migrate_change_column_comment_spec.rb
+++ b/spec/postgresql/migrate/migrate_change_column_comment_spec.rb
@@ -40,7 +40,6 @@ describe 'Ridgepole::Client#diff -> migrate' do
       ERB
 
       delta.migrate
-      puts subject.dump
       expect(subject.dump).to match_ruby expected_dsl
     }
   end


### PR DESCRIPTION
Currently, "changing a column comment" spec outputs a dump. https://github.com/ridgepole/ridgepole/actions/runs/17030072694/job/48271163923#step:5:15 https://github.com/ridgepole/ridgepole/actions/runs/17030072694/job/48271163937#step:5:15

But, this isn't related with the assertions. I assume this was just for debug.

