### PR TITLE
Remove needless version check

### DIFF
--- a/lib/ridgepole/delta.rb
+++ b/lib/ridgepole/delta.rb
@@ -438,7 +438,7 @@ rename_column(#{table_name.inspect}, #{from_column_name.inspect}, #{to_column_na
       options = attrs[:options] || {}
 
       # Fix for https://github.com/rails/rails/commit/7f0567b43b73b1bd1a16bfac9cd32fcbf1321b51
-      if Ridgepole::ConnectionAdapters.mysql? && ActiveRecord::VERSION::STRING !~ /\A5\.0\./
+      if Ridgepole::ConnectionAdapters.mysql?
         options[:comment] = nil unless options.key?(:comment)
       end
 


### PR DESCRIPTION
Ridgepole only supports Active Record >= 6.1 now.
So the check was always true.
