### PR TITLE
Update the issue template to the new format

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,3 +1,12 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
 <!--
 Please be sure to write the following information:
 (以下の情報を必ず書いてください)


### PR DESCRIPTION
Currently, ridgepole uses the old version of issue template and it doesn't work.
You can see the warning in the page.
https://github.com/ridgepole/ridgepole/blob/3.0/.github/issue_template.md

<img width="1573" height="597" alt="github com_ridgepole_ridgepole_blob_3 0_ github_issue_template md" src="https://github.com/user-attachments/assets/f7aac2e2-6058-4234-8fdf-c7a7d36cac8a" />

This PR migrate the issue template to the new place.
