### PR TITLE
Document renamed_from change detection limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,13 @@ create_table "user_comments", force: :cascade, renamed_from: "comments" do |t|
 end
 ```
 
+> [!note]
+> When using `renamed_from` on a table, Ridgepole will only perform the rename operation. All other changes to that table (columns, indexes, foreign keys, etc.) will not be detected during the same migration.
+>
+> If you need to rename AND modify a table, do it in two separate steps:
+> 1. First migration: Add `renamed_from` to rename the table
+> 2. Second migration: Remove `renamed_from` and apply your desired changes
+
 ## Foreign Key
 ```ruby
 create_table "parent", force: :cascade do |t|

--- a/spec/mysql/migrate/migrate_rename_table_with_changes_spec.rb
+++ b/spec/mysql/migrate/migrate_rename_table_with_changes_spec.rb
@@ -1,0 +1,190 @@
+# frozen_string_literal: true
+
+describe 'Ridgepole::Client#diff -> migrate' do
+  context 'when rename table with column addition' do
+    let(:actual_dsl) do
+      erbh(<<-ERB)
+        create_table "comments", force: :cascade do |t|
+          t.string "commenter"
+          t.text   "body"
+          t.integer "article_id"
+        end
+      ERB
+    end
+
+    let(:expected_dsl) do
+      erbh(<<-ERB)
+        create_table "user_comments", force: :cascade, renamed_from: "comments" do |t|
+          t.string "commenter"
+          t.text   "body"
+          t.integer "article_id"
+          t.string "status"
+        end
+      ERB
+    end
+
+    before { subject.diff(actual_dsl).migrate }
+    subject { client }
+
+    it 'should only rename the table, not add the column' do
+      delta = subject.diff(expected_dsl)
+      expect(delta.differ?).to be_truthy
+      expect(subject.dump).to match_ruby actual_dsl
+      delta.migrate
+      expect(subject.dump).to match_fuzzy <<-RUBY
+        create_table "user_comments", force: :cascade do |t|
+          t.string "commenter"
+          t.text   "body"
+          t.integer "article_id"
+        end
+      RUBY
+      expect(subject.dump).not_to match_fuzzy <<-RUBY
+        t.string "status"
+      RUBY
+    end
+  end
+
+  context 'when rename table with index addition' do
+    let(:actual_dsl) do
+      erbh(<<-ERB)
+        create_table "comments", force: :cascade do |t|
+          t.string "commenter"
+          t.text   "body"
+          t.integer "article_id"
+        end
+      ERB
+    end
+
+    let(:expected_dsl) do
+      erbh(<<-ERB)
+        create_table "user_comments", force: :cascade, renamed_from: "comments" do |t|
+          t.string "commenter"
+          t.text   "body"
+          t.integer "article_id"
+          t.index ["article_id"], name: "index_article_id"
+        end
+      ERB
+    end
+
+    before { subject.diff(actual_dsl).migrate }
+    subject { client }
+
+    it 'should only rename the table, not add the index' do
+      delta = subject.diff(expected_dsl)
+      expect(delta.differ?).to be_truthy
+      expect(subject.dump).to match_ruby actual_dsl
+      delta.migrate
+      expect(subject.dump).to match_fuzzy <<-RUBY
+        create_table "user_comments", force: :cascade do |t|
+          t.string "commenter"
+          t.text   "body"
+          t.integer "article_id"
+        end
+      RUBY
+      expect(subject.dump).not_to match_fuzzy <<-RUBY
+        t.index ["article_id"], name: "index_article_id"
+      RUBY
+    end
+  end
+
+  context 'when rename table with column type change' do
+    let(:actual_dsl) do
+      erbh(<<-ERB)
+        create_table "comments", force: :cascade do |t|
+          t.string "commenter"
+          t.text   "body"
+          t.integer "article_id"
+        end
+      ERB
+    end
+
+    let(:expected_dsl) do
+      erbh(<<-ERB)
+        create_table "user_comments", force: :cascade, renamed_from: "comments" do |t|
+          t.string "commenter"
+          t.text   "body"
+          t.bigint "article_id"
+        end
+      ERB
+    end
+
+    before { subject.diff(actual_dsl).migrate }
+    subject { client }
+
+    it 'should only rename the table, not change the column type' do
+      delta = subject.diff(expected_dsl)
+      expect(delta.differ?).to be_truthy
+      expect(subject.dump).to match_ruby actual_dsl
+      delta.migrate
+      expect(subject.dump).to match_fuzzy <<-RUBY
+        create_table "user_comments", force: :cascade do |t|
+          t.string "commenter"
+          t.text   "body"
+          t.integer "article_id"
+        end
+      RUBY
+      expect(subject.dump).not_to match_fuzzy <<-RUBY
+        t.bigint "article_id"
+      RUBY
+    end
+  end
+
+  context 'when rename table with foreign key addition' do
+    let(:actual_dsl) do
+      erbh(<<-ERB)
+        create_table "articles", force: :cascade do |t|
+          t.string "title"
+        end
+
+        create_table "comments", force: :cascade do |t|
+          t.string "commenter"
+          t.text   "body"
+          t.integer "article_id"
+          t.index ["article_id"], name: "index_article_id"
+        end
+      ERB
+    end
+
+    let(:expected_dsl) do
+      erbh(<<-ERB)
+        create_table "articles", force: :cascade do |t|
+          t.string "title"
+        end
+
+        create_table "user_comments", force: :cascade, renamed_from: "comments" do |t|
+          t.string "commenter"
+          t.text   "body"
+          t.integer "article_id"
+          t.index ["article_id"], name: "index_article_id"
+        end
+
+        add_foreign_key "user_comments", "articles", name: "fk_comments_articles"
+      ERB
+    end
+
+    before { subject.diff(actual_dsl).migrate }
+    subject { client }
+
+    it 'should only rename the table, not add the foreign key' do
+      delta = subject.diff(expected_dsl)
+      expect(delta.differ?).to be_truthy
+      expect(subject.dump).to match_ruby actual_dsl
+      delta.migrate
+      expect(subject.dump).to match_fuzzy <<-RUBY
+        create_table "articles", force: :cascade do |t|
+          t.string "title"
+        end
+
+        create_table "user_comments", force: :cascade do |t|
+          t.string "commenter"
+          t.text   "body"
+          t.integer "article_id"
+          t.index ["article_id"], name: "index_article_id"
+        end
+      RUBY
+      expect(subject.dump).not_to match_fuzzy <<-RUBY
+        add_foreign_key "user_comments", "articles", name: "fk_comments_articles"
+      RUBY
+    end
+  end
+end

--- a/spec/postgresql/migrate/migrate_rename_table_with_changes_spec.rb
+++ b/spec/postgresql/migrate/migrate_rename_table_with_changes_spec.rb
@@ -1,0 +1,187 @@
+# frozen_string_literal: true
+
+describe 'Ridgepole::Client#diff -> migrate' do
+  context 'when rename table with column addition' do
+    let(:actual_dsl) do
+      erbh(<<-ERB)
+        create_table "comments", force: :cascade do |t|
+          t.string "commenter", limit: 255
+          t.text   "body"
+          t.integer "article_id"
+        end
+      ERB
+    end
+
+    let(:expected_dsl) do
+      erbh(<<-ERB)
+        create_table "user_comments", force: :cascade, renamed_from: "comments" do |t|
+          t.string "commenter", limit: 255
+          t.text   "body"
+          t.integer "article_id"
+          t.string "status", limit: 255
+        end
+      ERB
+    end
+
+    before { subject.diff(actual_dsl).migrate }
+    subject { client }
+
+    it 'should only rename the table, not add the column' do
+      delta = subject.diff(expected_dsl)
+      expect(delta.differ?).to be_truthy
+      expect(subject.dump).to match_ruby actual_dsl
+      delta.migrate
+      expect(subject.dump).to match_fuzzy <<-RUBY
+        create_table "user_comments", force: :cascade do |t|
+          t.string "commenter", limit: 255
+          t.text   "body"
+          t.integer "article_id"
+        end
+      RUBY
+      expect(subject.dump).not_to match_fuzzy <<-RUBY
+        t.string "status"
+      RUBY
+    end
+  end
+
+  context 'when rename table with index addition' do
+    let(:actual_dsl) do
+      erbh(<<-ERB)
+        create_table "comments", force: :cascade do |t|
+          t.string "commenter", limit: 255
+          t.text   "body"
+          t.integer "article_id"
+        end
+      ERB
+    end
+
+    let(:expected_dsl) do
+      erbh(<<-ERB)
+        create_table "user_comments", force: :cascade, renamed_from: "comments" do |t|
+          t.string "commenter", limit: 255
+          t.text   "body"
+          t.integer "article_id"
+          t.index ["article_id"], name: "index_article_id"
+        end
+      ERB
+    end
+
+    before { subject.diff(actual_dsl).migrate }
+    subject { client }
+
+    it 'should only rename the table, not add the index' do
+      delta = subject.diff(expected_dsl)
+      expect(delta.differ?).to be_truthy
+      expect(subject.dump).to match_ruby actual_dsl
+      delta.migrate
+      expect(subject.dump).to match_fuzzy <<-RUBY
+        create_table "user_comments", force: :cascade do |t|
+          t.string "commenter", limit: 255
+          t.text   "body"
+          t.integer "article_id"
+        end
+      RUBY
+      expect(subject.dump).not_to match_fuzzy <<-RUBY
+        t.index ["article_id"], name: "index_article_id"
+      RUBY
+    end
+  end
+
+  context 'when rename table with column type change' do
+    let(:actual_dsl) do
+      erbh(<<-ERB)
+        create_table "comments", force: :cascade do |t|
+          t.string "commenter", limit: 255
+          t.text   "body"
+          t.integer "article_id"
+        end
+      ERB
+    end
+
+    let(:expected_dsl) do
+      erbh(<<-ERB)
+        create_table "user_comments", force: :cascade, renamed_from: "comments" do |t|
+          t.string "commenter", limit: 255
+          t.text   "body"
+          t.bigint "article_id"
+        end
+      ERB
+    end
+
+    before { subject.diff(actual_dsl).migrate }
+    subject { client }
+
+    it 'should only rename the table, not change the column type' do
+      delta = subject.diff(expected_dsl)
+      expect(delta.differ?).to be_truthy
+      expect(subject.dump).to match_ruby actual_dsl
+      delta.migrate
+      expect(subject.dump).to match_fuzzy <<-RUBY
+        create_table "user_comments", force: :cascade do |t|
+          t.string "commenter", limit: 255
+          t.text   "body"
+          t.integer "article_id"
+        end
+      RUBY
+      expect(subject.dump).not_to match_fuzzy <<-RUBY
+        t.bigint "article_id"
+      RUBY
+    end
+  end
+
+  context 'when rename table with foreign key addition' do
+    let(:actual_dsl) do
+      erbh(<<-ERB)
+        create_table "articles", force: :cascade do |t|
+          t.string "title", limit: 255
+        end
+
+        create_table "comments", force: :cascade do |t|
+          t.string "commenter", limit: 255
+          t.text   "body"
+          t.integer "article_id"
+        end
+      ERB
+    end
+
+    let(:expected_dsl) do
+      erbh(<<-ERB)
+        create_table "articles", force: :cascade do |t|
+          t.string "title", limit: 255
+        end
+
+        create_table "user_comments", force: :cascade, renamed_from: "comments" do |t|
+          t.string "commenter", limit: 255
+          t.text   "body"
+          t.integer "article_id"
+        end
+
+        add_foreign_key "user_comments", "articles", name: "fk_comments_articles"
+      ERB
+    end
+
+    before { subject.diff(actual_dsl).migrate }
+    subject { client }
+
+    it 'should only rename the table, not add the foreign key' do
+      delta = subject.diff(expected_dsl)
+      expect(delta.differ?).to be_truthy
+      expect(subject.dump).to match_ruby actual_dsl
+      delta.migrate
+      expect(subject.dump).to match_fuzzy <<-RUBY
+        create_table "articles", force: :cascade do |t|
+          t.string "title", limit: 255
+        end
+
+        create_table "user_comments", force: :cascade do |t|
+          t.string "commenter", limit: 255
+          t.text   "body"
+          t.integer "article_id"
+        end
+      RUBY
+      expect(subject.dump).not_to match_fuzzy <<-RUBY
+        add_foreign_key "user_comments", "articles", name: "fk_comments_articles"
+      RUBY
+    end
+  end
+end


### PR DESCRIPTION
## Summary

  Document that `renamed_from` prevents change detection for the entire table during the same migration.

  ## Problem

  The current documentation in the [Rename section](https://github.com/ridgepole/ridgepole/blob/3.0/README.md#rename) demonstrates how to use the
  `renamed_from` option for renaming tables and columns, but it does not mention a critical limitation: when `renamed_from` is used on a table, all other changes to that table are silently ignored.

  ## Root Cause

  When using `renamed_from` on a table, the `scan_table_rename` method (in [lib/ridgepole/diff.rb lines 94-95](https://github.com/ridgepole/ridgepole/blob/72ad8c115bbf1232df0923d858dfcc3da898a2cf/lib/ridgepole/diff.rb#L94-L95)) removes both the old and new table
  names from the comparison hashes.

  ## Changes

  1. README.md: Added note and two-step workaround documentation (Please let me know if you'd prefer a different approach for documenting this limitation.)
  2. Test coverage: Added test cases for both MySQL and PostgreSQL


<!--
Thank you for your pull request.
It would be helpful if you could clarify the problem by creating an issue first.
-->
