### PR TITLE
doc: add description about the limitation and to avoid unnecessary migration related to CHECK constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,31 @@ add_index "child", ["parent_id"], name: "par_ind", using: :btree
 add_foreign_key "child", "parent", name: "child_ibfk_1"
 ```
 
+## CHECK Constraint
+
+```ruby
+create_table "products", force: :cascade do |t|
+  t.string  "name", null: false
+  t.decimal "price", precision: 10, scale: 2
+  t.integer "quantity"
+
+  t.check_constraint "price > 0", name: "price_check"
+  t.check_constraint "quantity >= 0", name: "quantity_check"
+end
+```
+
+> [!important]
+> **Matching Schemafile to Database Output**
+>
+> CHECK constraint expressions may be formatted differently by your database when exported. For example:
+> - DSL: `"(price > 0)"`
+> - Database export: `` "`price` > 0" `` (MySQL) or `"((price > 0))"` (PostgreSQL)
+>
+> To avoid unnecessary migrations where constraints are dropped and recreated:
+> Please modify your Schemafile to match exactly what the SchemaDumper outputs. This approach maintains simplicity and prevents migration issues instead of maintaining complex normalization logic in Ridgepole.
+>
+> Run `ridgepole --export` to see the exact format your database uses, then update your Schemafile accordingly.
+
 ## Ignore Column/Index/FK
 
 ```ruby


### PR DESCRIPTION
~Fixes #609 where CHECK constraints were unnecessarily dropped and recreated during migrations due to differences in expression formats between RDBMS (from) and DSL (to), even when the constraints were semantically identical.~

~NOTE: This change might not be comprehensive, so it may be necessary to expand the normalization logic, but it should be sufficient for most use cases.~

[UPDATE]
In accordance with https://github.com/ridgepole/ridgepole/pull/611#issuecomment-3480289494, the intention of this pull request changed to modify the doc.