### PR TITLE
Add benchmark gem

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -2,30 +2,44 @@
 
 appraise 'activerecord-6.1' do
   gem 'activerecord', '~> 6.1.7'
+  gem 'benchmark'
+  gem 'mutex_m'
 end
 
 appraise 'activerecord-7.0' do
   gem 'activerecord', '~> 7.0.4'
+  gem 'benchmark'
+  gem 'mutex_m'
 end
 
 appraise 'activerecord-7.1' do
   gem 'activerecord', '~> 7.1.0'
+  gem 'benchmark'
+  gem 'mutex_m'
 end
 
 appraise 'activerecord-7.2' do
   gem 'activerecord', '~> 7.2.0'
+  gem 'benchmark'
+  gem 'mutex_m'
 end
 
 appraise 'activerecord-8.0' do
   gem 'activerecord', '~> 8.0.0'
+  gem 'benchmark'
+  gem 'mutex_m'
 end
 
 appraise 'activerecord-8.1' do
   gem 'activerecord', '~> 8.1.0'
+  gem 'benchmark'
+  gem 'mutex_m'
 end
 
 appraise 'activerecord-8.2' do
   git 'https://github.com/rails/rails.git' do
     gem 'activerecord', '~> 8.2.0.alpha', '< 8.3.0.alpha'
   end
+  gem 'benchmark'
+  gem 'mutex_m'
 end

--- a/gemfiles/activerecord_6.1.gemfile
+++ b/gemfiles/activerecord_6.1.gemfile
@@ -4,5 +4,6 @@ source "https://rubygems.org"
 
 gem "mutex_m"
 gem "activerecord", "~> 6.1.7"
+gem "benchmark"
 
 gemspec path: "../"

--- a/gemfiles/activerecord_7.0.gemfile
+++ b/gemfiles/activerecord_7.0.gemfile
@@ -4,5 +4,6 @@ source "https://rubygems.org"
 
 gem "mutex_m"
 gem "activerecord", "~> 7.0.4"
+gem "benchmark"
 
 gemspec path: "../"

--- a/gemfiles/activerecord_7.1.gemfile
+++ b/gemfiles/activerecord_7.1.gemfile
@@ -4,5 +4,6 @@ source "https://rubygems.org"
 
 gem "mutex_m"
 gem "activerecord", "~> 7.1.0"
+gem "benchmark"
 
 gemspec path: "../"

--- a/gemfiles/activerecord_7.2.gemfile
+++ b/gemfiles/activerecord_7.2.gemfile
@@ -4,5 +4,6 @@ source "https://rubygems.org"
 
 gem "mutex_m"
 gem "activerecord", "~> 7.2.0"
+gem "benchmark"
 
 gemspec path: "../"

--- a/gemfiles/activerecord_8.0.gemfile
+++ b/gemfiles/activerecord_8.0.gemfile
@@ -4,5 +4,6 @@ source "https://rubygems.org"
 
 gem "mutex_m"
 gem "activerecord", "~> 8.0.0"
+gem "benchmark"
 
 gemspec path: "../"

--- a/gemfiles/activerecord_8.1.gemfile
+++ b/gemfiles/activerecord_8.1.gemfile
@@ -4,5 +4,6 @@ source "https://rubygems.org"
 
 gem "mutex_m"
 gem "activerecord", "~> 8.1.0"
+gem "benchmark"
 
 gemspec path: "../"

--- a/gemfiles/activerecord_8.2.gemfile
+++ b/gemfiles/activerecord_8.2.gemfile
@@ -7,5 +7,6 @@ git "https://github.com/rails/rails.git" do
 end
 
 gem "mutex_m"
+gem "benchmark"
 
 gemspec path: "../"


### PR DESCRIPTION
fix for following warning:

> activesupport-7.0.8.7/lib/active_support/core_ext/benchmark.rb:3: warning: benchmark was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.