### PR TITLE
Add Ruby 4.0 CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,7 @@ jobs:
           - "3.2"
           - "3.3"
           - "3.4"
+          - "4.0"
         env:
           - MYSQL57=1
           - MYSQL80=1
@@ -45,9 +46,13 @@ jobs:
             gemfile: gemfiles/activerecord_6.1.gemfile
           - ruby: "3.4"
             gemfile: gemfiles/activerecord_6.1.gemfile
+          - ruby: "4.0"
+            gemfile: gemfiles/activerecord_6.1.gemfile
           - ruby: "3.3"
             gemfile: gemfiles/activerecord_7.0.gemfile
           - ruby: "3.4"
+            gemfile: gemfiles/activerecord_7.0.gemfile
+          - ruby: "4.0"
             gemfile: gemfiles/activerecord_7.0.gemfile
           - ruby: "2.7"
             gemfile: gemfiles/activerecord_7.2.gemfile


### PR DESCRIPTION
Thank you for always maintaining ridgepole. 🚀

Taking into account that Ruby 4.0.0 will be released on December 25 and that Ruby 4.0 preview3 has already been released, we would like to explicitly support Ruby 4.0.0 preview3 and Ruby 4.0 in ridgepole.

## ref
Ruby 4.0.0 preview3 release notes: https://www.ruby-lang.org/en/news/2025/12/18/ruby-4-0-0-preview3-released/