### PR TITLE
Fix spurious diff for partial indexes on PostgreSQL due to WHERE clause parentheses

### DIFF
--- a/lib/ridgepole/diff.rb
+++ b/lib/ridgepole/diff.rb
@@ -475,6 +475,27 @@ module Ridgepole
 
       # 'algorithm: concurrently' is required for index creation but not stored in PostgreSQL DB metadata, so remove 'algorithm' to prevent diff
       opts.delete(:algorithm)
+
+      # PostgreSQL's pg_get_indexdef() wraps WHERE clauses in parentheses
+      # (e.g., "(deleted_at IS NULL)"), but Schemafile definitions typically
+      # omit them (e.g., "deleted_at IS NULL"). Strip the outermost parentheses
+      # to prevent spurious diffs for partial indexes.
+      opts[:where] = strip_outer_parentheses(opts[:where]) if opts[:where].is_a?(String)
+    end
+
+    def strip_outer_parentheses(str)
+      return str unless str.start_with?('(') && str.end_with?(')')
+
+      depth = 0
+      str.each_char.with_index do |char, i|
+        depth += 1 if char == '('
+        depth -= 1 if char == ')'
+        # If depth reaches 0 before the last character,
+        # the outermost parentheses do not wrap the entire expression
+        return str if depth == 0 && i < str.length - 1
+      end
+
+      str[1..-2]
     end
 
     def columns_all_include?(expected_columns, actual_columns, table_options)

--- a/spec/postgresql/migrate/migrate_idempotent_partial_index_spec.rb
+++ b/spec/postgresql/migrate/migrate_idempotent_partial_index_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+describe 'Ridgepole::Client#diff -> migrate' do
+  let(:dsl) do
+    erbh(<<-ERB)
+      create_table "clubs", id: :serial, force: :cascade do |t|
+        t.string "name", limit: 255, default: "", null: false
+        t.datetime "deleted_at"
+        t.index ["name"], name: "idx_name", unique: true
+        t.index ["name"], name: "idx_name_not_deleted", where: "(deleted_at IS NULL)"
+      end
+    ERB
+  end
+
+  let(:dsl_without_parens) do
+    erbh(<<-ERB)
+      create_table "clubs", id: :serial, force: :cascade do |t|
+        t.string "name", limit: 255, default: "", null: false
+        t.datetime "deleted_at"
+        t.index ["name"], name: "idx_name", unique: true
+        t.index ["name"], name: "idx_name_not_deleted", where: "deleted_at IS NULL"
+      end
+    ERB
+  end
+
+  before { subject.diff(dsl).migrate }
+  subject { client }
+
+  it 'should not detect diff when WHERE clause has parentheses' do
+    delta = subject.diff(dsl)
+    expect(delta.differ?).to be_falsey
+  end
+
+  it 'should not detect diff when WHERE clause omits parentheses' do
+    delta = subject.diff(dsl_without_parens)
+    expect(delta.differ?).to be_falsey
+  end
+
+  it 'should not corrupt WHERE clause where parentheses do not wrap entire expression' do
+    # "(a) OR (b)" style should not be stripped
+    dsl_partial_parens = erbh(<<-ERB)
+      create_table "clubs", id: :serial, force: :cascade do |t|
+        t.string "name", limit: 255, default: "", null: false
+        t.integer "status", default: 0, null: false
+        t.datetime "deleted_at"
+        t.index ["name"], name: "idx_name", unique: true
+        t.index ["name"], name: "idx_name_conditional", where: "(status = 1) OR (deleted_at IS NULL)"
+      end
+    ERB
+    subject.diff(dsl_partial_parens).migrate
+    delta = subject.diff(dsl_partial_parens)
+    expect(delta.differ?).to be_falsey
+  end
+end


### PR DESCRIPTION
### Summary

Fix spurious diff detection for partial indexes (conditional indexes) on PostgreSQL, which caused `ridgepole --apply` to drop and recreate them on every run.

### Problem

When a Schemafile defines a partial index like:

```ruby
add_index "users", ["email"], name: "index_users_on_email_active",
                              where: "deleted_at IS NULL"
```

PostgreSQL internally normalizes the WHERE clause by wrapping it in parentheses. The `pg_get_indexdef()` function (used by ActiveRecord's `SchemaDumper`) returns:

```sql
WHERE (deleted_at IS NULL)
```

Ridgepole dumps the DB state via `ActiveRecord::SchemaDumper`, which produces `where: "(deleted_at IS NULL)"`. When `scan_indices_change` compares this against the Schemafile's `where: "deleted_at IS NULL"`, the strings differ, and Ridgepole detects a change every time — even though the indexes are semantically identical.

This breaks the idempotency of `--apply`: a second consecutive run produces unnecessary `remove_index` / `add_index` operations:

```
Apply `Schemafile`
-- remove_index("users", {name: "index_users_on_email_active"})
   -> 0.0051s
-- add_index("users", ["email"], {name: "index_users_on_email_active", where: "deleted_at IS NULL", using: :btree, unique: false})
   -> 0.0038s
```

### Root Cause

`normalize_index_options!` in `lib/ridgepole/diff.rb` normalizes `:using` and `:unique` but does not normalize the `:where` option. The comparison at line 384 (`from_attrs != to_attrs`) then fails due to the parenthesized vs. non-parenthesized WHERE string.

### Fix

Strip the outermost parentheses from the `:where` option in `normalize_index_options!` so that both the Schemafile side and the DB-dumped side are compared in the same form.

### Safety

`normalize_index_options!` is a mutating method, and the normalized value is also used when generating migration statements. However, stripping the outermost parentheses from a SQL conditional expression never changes its semantics — `WHERE (expr)` and `WHERE expr` are equivalent regardless of the complexity of `expr`. PostgreSQL itself re-normalizes the expression when creating the index, so the resulting index is identical either way.

Note: This fix addresses single-condition WHERE clauses (e.g., `deleted_at IS NULL`). Compound conditions (e.g., `status = 1 AND deleted_at IS NULL`) involve deeper parenthesization by PostgreSQL and remain a separate issue.

### Reproduction Steps

```bash
# 1. Create a table with a partial index (where clause without parentheses)
# Schemafile:
#   add_index "users", ["email"], name: "index_users_on_email_active", where: "deleted_at IS NULL"

# 2. Apply twice
bundle exec ridgepole --apply -c config/database.yml  # 1st: creates index
bundle exec ridgepole --apply -c config/database.yml  # 2nd: should be no-op

# Before fix: 2nd apply drops and recreates the index
# After fix:  2nd apply produces no diff
```

### Verification

After the fix, the following was confirmed:

| Schemafile `where:` | 1st apply | 2nd apply |
|---|---|---|
| `'deleted_at IS NULL'` (no parens) | Creates index ✅ | **No diff** ✅ |
| `'(deleted_at IS NULL)'` (with parens) | Creates index ✅ | **No diff** ✅ |

Both forms are now treated as equivalent, and `--apply` is idempotent for partial indexes.