### PR TITLE
Fix generated column noop diffs on MySQL

### DIFF
--- a/lib/ridgepole/diff.rb
+++ b/lib/ridgepole/diff.rb
@@ -679,7 +679,43 @@ module Ridgepole
         MSG
       end
 
+      normalize_generated_column_expression!(attrs1)
+      normalize_generated_column_expression!(attrs2)
+
       attrs1 == attrs2
+    end
+
+    def normalize_generated_column_expression!(attrs)
+      return unless Ridgepole::ConnectionAdapters.mysql?
+      return unless attrs[:type] == :virtual
+
+      expr = attrs.dig(:options, :as)
+      return unless expr
+
+      attrs[:options][:as] = normalize_generated_column_expression(expr)
+    end
+
+    def normalize_generated_column_expression(expr)
+      expr = downcase_outside_quoted_strings(expr)
+
+      expr.gsub(/\(\s*([^()]+?\s+is\s+(?:not\s+)?null)\s*\)/, '\1')
+    end
+
+    def downcase_outside_quoted_strings(expr)
+      quote = nil
+      escaped = false
+
+      expr.each_char.map do |char|
+        if quote
+          current = char
+          escaped = !escaped && char == '\\' && quote != '`'
+          quote = nil if char == quote && !escaped
+          current
+        else
+          quote = char if ['"', "'", '`'].include?(char)
+          char.downcase
+        end
+      end.join
     end
 
     def comment_only_change?(attrs1, attrs2)

--- a/spec/mysql/virtual/change_virtual_column_spec.rb
+++ b/spec/mysql/virtual/change_virtual_column_spec.rb
@@ -154,4 +154,32 @@ describe 'Ridgepole::Client#diff -> migrate' do
       expect { delta.migrate }.to raise_error(RuntimeError)
     }
   end
+
+  context 'when generated column expression is normalized by MySQL (issue #680)' do
+    let(:expected_dsl) do
+      <<-RUBY
+        create_table "generated_column_repros", id: { type: :bigint, unsigned: true }, charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+          t.datetime "deleted_at"
+          t.virtual "active_unique_key", type: :integer, as: "if(`deleted_at` IS NULL,1,NULL)", stored: true
+        end
+      RUBY
+    end
+
+    subject { client(dump_without_table_options: false) }
+
+    it {
+      subject.diff(expected_dsl).migrate
+
+      expect(subject.dump).to match_ruby <<-RUBY
+        create_table "generated_column_repros", id: { type: :bigint, unsigned: true }, charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+          t.virtual "active_unique_key", type: :integer, as: "if((`deleted_at` is null),1,NULL)", stored: true
+          t.datetime "deleted_at"
+        end
+      RUBY
+
+      delta = subject.diff(expected_dsl)
+      expect(delta.differ?).to be_falsey
+      expect(delta.script).to eq ''
+    }
+  end
 end


### PR DESCRIPTION
## What
Fixes a no-op diff for MySQL generated columns when MySQL normalizes the generated expression after apply.

## Why
Applying the same Schemafile could keep producing `change_column(..., comment: nil)` for generated columns because Ridgepole compared the raw `as:` expression literally.

## Root cause
MySQL normalizes generated column expressions during dump/DDL introspection, including lowercasing `IS NULL` and adding extra parentheses. Ridgepole treated those normalized forms as real schema changes.

## Changes
- normalize MySQL generated column expressions before comparing virtual column definitions
- preserve the existing whitespace-only warning behavior
- add a regression spec for issue #680

## Validation
- `bundle exec ruby -c lib/ridgepole/diff.rb`
- `bundle exec ruby -c spec/mysql/virtual/change_virtual_column_spec.rb`
- verified with a direct MySQL 8 repro script that the second diff becomes empty after apply

## Notes
RSpec against MySQL 8 could not be completed in this local environment because the test setup hit `caching_sha2_password` secure-connection authentication errors during reconnect/schema dump.
