### PR TITLE
Update test.yml to specify version 11.2.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,6 +103,7 @@ jobs:
           fail_ci_if_error: true
           flags: ${{ matrix.ruby }},${{ matrix.gemfile }},${{ matrix.env }}
           files: ./junit_format/rspec_xml
+          version: 11.2.7
       # NOTE: This check isn't very useful and slows down processing, so I'll comment it out.
       # - name: Build and install gem
       #   run: |


### PR DESCRIPTION
This pull request introduces a minor update to the test workflow configuration, specifically by specifying the version of a tool used in the CI process.

- Workflow configuration update:
  * [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R106): Added the `version: 11.2.7` field to the configuration for improved clarity and reproducibility in the CI environment.<!--
Thank you for your pull request.
It would be helpful if you could clarify the problem by creating an issue first.
-->
