### PR TITLE
ci: do not fail CI on Codecov upload errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,14 +93,14 @@ jobs:
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           flags: ${{ matrix.ruby }},${{ matrix.gemfile }},${{ matrix.env }}
       - name: Upload test results to Codecov
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           report_type: test_results
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           flags: ${{ matrix.ruby }},${{ matrix.gemfile }},${{ matrix.env }}
           files: ./junit_format/rspec_xml
       # NOTE: This check isn't very useful and slows down processing, so I'll comment it out.


### PR DESCRIPTION
## Summary

- A transient Codecov upload failure on PR #688 caused the entire test matrix to fail: with `fail_ci_if_error: true`, the failing upload made the matrix job exit non-zero, and `fail-fast: true` cancelled the remaining 115 sibling jobs.
- The only annotation on the failing job (`test (3.1, POSTGRESQL, activerecord_6.1.gemfile)`) was `Upload coverage to Codecov` — the test step itself succeeded.
- Coverage upload outages shouldn't take down unrelated test jobs, so flip `fail_ci_if_error` to `false` for both Codecov steps (coverage + test results).

Reference failing run: https://github.com/ridgepole/ridgepole/actions/runs/25114385852/job/73597117714?pr=688

## Test plan

- [ ] CI passes on this PR
- [ ] Codecov upload still runs (just no longer blocks CI when it errors)

https://claude.ai/code/session_01EiLuptjC4RJVHRXxc6XSF7

---
_Generated by [Claude Code](https://claude.ai/code/session_01EiLuptjC4RJVHRXxc6XSF7)_