### PR TITLE
Update ruby/setup-ruby action version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: ruby/setup-ruby@7372622e62b60b3cb750dcd2b9e32c247ffec26a # v1.302.0
+      - uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow by upgrading the `ruby/setup-ruby` action to a newer version. This ensures the CI pipeline uses the latest features and bug fixes from the action.

* Upgraded the `ruby/setup-ruby` action in `.github/workflows/test.yml` from version `v1.302.0` to `v1.306.0` to keep the CI environment up to date.
