### PR TITLE
Bump version to 3.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 3.2
 
+### 3.2.1 (2026/05/04)
+
+- Warn when an anonymous index ambiguously matches multiple DB indexes. [pull#692](https://github.com/ridgepole/ridgepole/pull/692)
+
 ### 3.2.0 (2026/03/28)
 
 - Fix spurious diff for `timestamp`/`datetime` with `precision: 6` on MySQL. [pull#665](https://github.com/ridgepole/ridgepole/pull/665)

--- a/lib/ridgepole/version.rb
+++ b/lib/ridgepole/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Ridgepole
-  VERSION = '3.2.0'
+  VERSION = '3.2.1'
 end


### PR DESCRIPTION
## Summary
- Bump `Ridgepole::VERSION` to `3.2.1` and add the matching CHANGELOG entry.

## Included since 3.2.0
- Warn when an anonymous index ambiguously matches multiple DB indexes ([#692](https://github.com/ridgepole/ridgepole/pull/692))

## Test plan
- [x] Verify CHANGELOG format matches prior entries
- [x] `lib/ridgepole/version.rb` reflects the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)