### PR TITLE
Describe features of similar tools in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ It defines DB schema using [Rails DSL](http://guides.rubyonrails.org/migrations.
 [![codecov](https://codecov.io/gh/ridgepole/ridgepole/graph/badge.svg)](https://codecov.io/gh/ridgepole/ridgepole)
 
 > [!TIP]
-> Currently developing similar tools.
-> 
-> * https://github.com/winebarrel/pistachio
-> * https://github.com/winebarrel/myschema
+> Also developing similar declarative schema tools — single Go binary, plain SQL as the schema definition:
+>
+> * [pistachio](https://github.com/winebarrel/pistachio) — for PostgreSQL
+> * [myschema](https://github.com/winebarrel/myschema) — for MySQL
 
 > [!warning]
 > The order of columns when exporting has changed in Rails 8.1. https://github.com/rails/rails/pull/53281


### PR DESCRIPTION
## Summary
- Rewrite the TIP callout introducing pistachio / myschema so it conveys what they actually are (declarative schema management, single Go binary, plain SQL) and which DB each targets.
- Convert bare URLs to named Markdown links.

## Test plan
- [ ] Verify the rendered README on GitHub still shows the TIP callout correctly with working links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)