### PR TITLE
Update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
+      - uses: ruby/setup-ruby@97ecb7b512899eb71ab1bf2310a624c6f1589ac6 # v1.308.0
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
@@ -90,13 +90,13 @@ jobs:
         env:
           RUBYOPT: --enable-frozen-string-literal
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        uses: codecov/codecov-action@cddd853df119a48c5be31a973f8cd97e12e35e16 # v6.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           flags: ${{ matrix.ruby }},${{ matrix.gemfile }},${{ matrix.env }}
       - name: Upload test results to Codecov
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        uses: codecov/codecov-action@cddd853df119a48c5be31a973f8cd97e12e35e16 # v6.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           report_type: test_results


### PR DESCRIPTION
## Summary

- `ruby/setup-ruby` v1.306.0 → v1.308.0
- `codecov/codecov-action` v6.0.0 → v6.0.1
- `actions/checkout` v6.0.2 is already the latest

SHA pinning style (with version comments) is preserved.

## Test plan

- [ ] CI passes on this branch


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qv4PYG8ZkSFv6VaFeHsvWK)_