### PR TITLE
Bump up and Update Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 3.2
 
+### 3.2.2 (2026/06/14)
+
+- Fix constraint removal order when dropping columns. [pull#705](https://github.com/ridgepole/ridgepole/pull/705)
+
 ### 3.2.1 (2026/05/04)
 
 - Warn when an anonymous index ambiguously matches multiple DB indexes. [pull#692](https://github.com/ridgepole/ridgepole/pull/692)

--- a/lib/ridgepole/version.rb
+++ b/lib/ridgepole/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Ridgepole
-  VERSION = '3.2.1'
+  VERSION = '3.2.2'
 end


### PR DESCRIPTION
This pull request updates the version of Ridgepole to `3.2.2` and documents a bug fix related to constraint removal order when dropping columns.

Version bump and release notes:

* Updated the version in `lib/ridgepole/version.rb` from `3.2.1` to `3.2.2`.
* Added a changelog entry for version `3.2.2` in `CHANGELOG.md`, noting the fix for constraint removal order when dropping columns.
