### PR TITLE
Ignore `validate: false` diff when existing constraint lacks `:validate`

### DIFF
--- a/lib/ridgepole/diff.rb
+++ b/lib/ridgepole/diff.rb
@@ -524,7 +524,7 @@ module Ridgepole
         next if ignore_fk
 
         if from_attrs
-          if from_attrs != to_attrs
+          if from_attrs != to_attrs && !ignorable_validate_diff?(from_attrs, to_attrs)
             foreign_keys_delta[:add] ||= {}
             foreign_keys_delta[:add][foreign_key_name_or_tables] = to_attrs
 
@@ -558,7 +558,9 @@ module Ridgepole
         from_attrs = from.delete(name)
 
         if from_attrs
-          if normalize_check_constraint(from_attrs) != normalize_check_constraint(to_attrs)
+          from_normalized = normalize_check_constraint(from_attrs)
+          to_normalized = normalize_check_constraint(to_attrs)
+          if from_normalized != to_normalized && !ignorable_validate_diff?(from_normalized, to_normalized)
             check_constraints_delta[:add] ||= {}
             check_constraints_delta[:add][name] = to_attrs
 
@@ -585,6 +587,20 @@ module Ridgepole
       attr = attr.dup
       attr[:expression] = attr[:expression].delete(REGEX_COLUMN_IDENTIFIER_QUOTATION_CHARS)
       attr
+    end
+
+    # 'validate: false' (NOT VALID) is a strategy for ALTER TABLE ADD CONSTRAINT to avoid
+    # ACCESS EXCLUSIVE lock on large tables. NOT VALID state itself is persisted by the DB,
+    # but PostgreSQL ignores NOT VALID for constraints created inline within CREATE TABLE, so
+    # whether the resulting constraint is NOT VALID depends on how it was created. Restoring
+    # NOT VALID via DROP + ADD has no benefit, so ignore the diff when the DB dump lacks
+    # :validate and the DSL specifies validate: false.
+    def ignorable_validate_diff?(from_attrs, to_attrs)
+      from_options = from_attrs[:options] || {}
+      to_options = to_attrs[:options] || {}
+      return false unless to_options[:validate] == false && !from_options.key?(:validate)
+
+      from_attrs == to_attrs.merge(options: to_options.except(:validate))
     end
 
     def scan_exclusion_constraints_change(from, to, table_delta)

--- a/spec/postgresql/diff/diff_spec.rb
+++ b/spec/postgresql/diff/diff_spec.rb
@@ -305,4 +305,137 @@ describe 'Ridgepole::Client.diff' do
       end
     end
   end
+
+  context 'when add foreign key with validate: false' do
+    subject { Ridgepole::Client }
+
+    context 'when foreign key does not exist' do
+      let(:actual_dsl) do
+        <<-RUBY
+          create_table "users", force: :cascade do |t|
+            t.string "name", null: false
+          end
+
+          create_table "entries", force: :cascade do |t|
+            t.bigint "user_id", null: false
+          end
+        RUBY
+      end
+
+      let(:expected_dsl) do
+        <<-RUBY
+          create_table "users", force: :cascade do |t|
+            t.string "name", null: false
+          end
+
+          create_table "entries", force: :cascade do |t|
+            t.bigint "user_id", null: false
+          end
+
+          add_foreign_key "entries", "users", validate: false
+        RUBY
+      end
+
+      it 'creates foreign key with validate: false' do
+        delta = subject.diff(actual_dsl, expected_dsl)
+        expect(delta).to be_differ
+        expect(delta.script).to match_ruby(<<-RUBY)
+          add_foreign_key("entries", "users", **{validate: false})
+        RUBY
+      end
+    end
+
+    context 'when foreign key exists without validate' do
+      let(:actual_dsl) do
+        <<-RUBY
+          create_table "users", force: :cascade do |t|
+            t.string "name", null: false
+          end
+
+          create_table "entries", force: :cascade do |t|
+            t.bigint "user_id", null: false
+          end
+
+          add_foreign_key "entries", "users"
+        RUBY
+      end
+
+      let(:expected_dsl) do
+        <<-RUBY
+          create_table "users", force: :cascade do |t|
+            t.string "name", null: false
+          end
+
+          create_table "entries", force: :cascade do |t|
+            t.bigint "user_id", null: false
+          end
+
+          add_foreign_key "entries", "users", validate: false
+        RUBY
+      end
+
+      it 'does not recreate foreign key just for validate: false' do
+        delta = subject.diff(actual_dsl, expected_dsl)
+        expect(delta).to_not be_differ
+        expect(delta.script).to be_empty
+      end
+    end
+  end
+
+  context 'when add check constraint with validate: false' do
+    subject { Ridgepole::Client }
+
+    context 'when check constraint does not exist' do
+      let(:actual_dsl) do
+        <<-RUBY
+          create_table "products", force: :cascade do |t|
+            t.integer "price", null: false
+          end
+        RUBY
+      end
+
+      let(:expected_dsl) do
+        <<-RUBY
+          create_table "products", force: :cascade do |t|
+            t.integer "price", null: false
+            t.check_constraint "price > 0", name: "products_price_check", validate: false
+          end
+        RUBY
+      end
+
+      it 'creates check constraint with validate: false' do
+        delta = subject.diff(actual_dsl, expected_dsl)
+        expect(delta).to be_differ
+        expect(delta.script).to match_ruby(<<-RUBY)
+          add_check_constraint("products", "price > 0", **{name: "products_price_check", validate: false})
+        RUBY
+      end
+    end
+
+    context 'when check constraint exists without validate' do
+      let(:actual_dsl) do
+        <<-RUBY
+          create_table "products", force: :cascade do |t|
+            t.integer "price", null: false
+            t.check_constraint "price > 0", name: "products_price_check"
+          end
+        RUBY
+      end
+
+      let(:expected_dsl) do
+        <<-RUBY
+          create_table "products", force: :cascade do |t|
+            t.integer "price", null: false
+            t.check_constraint "price > 0", name: "products_price_check", validate: false
+          end
+        RUBY
+      end
+
+      it 'does not recreate check constraint just for validate: false' do
+        delta = subject.diff(actual_dsl, expected_dsl)
+        expect(delta).to_not be_differ
+        expect(delta.script).to be_empty
+      end
+    end
+  end
 end


### PR DESCRIPTION
`validate: false` (NOT VALID) is an ALTER TABLE ADD CONSTRAINT strategy for avoiding ACCESS EXCLUSIVE lock on large tables. NOT VALID state itself is persisted by the DB, but PostgreSQL ignores NOT VALID for constraints created inline within CREATE TABLE — so applying the same schema can leave the DB constraint validated, causing a spurious diff on the next run that would churn the constraint via DROP + re-ADD.

Restoring NOT VALID via DROP + ADD has no benefit (its purpose is create-time lock avoidance), so ignore the diff when the DB dump lacks `:validate` and the DSL specifies `validate: false`. The reverse case (DB is NOT VALID, DSL implies validated) is left as-is — the proper fix there is to emit `validate_constraint`, which is out of scope here.

Covers foreign keys and check constraints.

<!--
Thank you for your pull request.
It would be helpful if you could clarify the problem by creating an issue first.
-->
