### PR TITLE
Emit `validate_constraint` when DB is NOT VALID and DSL implies validated

### DIFF
--- a/lib/ridgepole/delta.rb
+++ b/lib/ridgepole/delta.rb
@@ -568,6 +568,10 @@ remove_index(#{table_name.inspect}, #{target})
       (delta[:add] || {}).each_value do |attrs|
         append_add_foreign_key(table_name, attrs, post_buf, options)
       end
+
+      (delta[:validate] || {}).each_value do |attrs|
+        append_validate_foreign_key(table_name, attrs, post_buf)
+      end
     end
 
     def append_add_foreign_key(table_name, attrs, buf, _options)
@@ -594,6 +598,21 @@ remove_foreign_key(#{table_name.inspect}, #{target})
     RUBY
     end
 
+    def append_validate_foreign_key(table_name, attrs, buf)
+      attrs_options = attrs[:options] || {}
+      fk_name = attrs_options[:name]
+
+      target = if fk_name
+                 "name: #{fk_name.inspect}"
+               else
+                 attrs.fetch(:to_table).inspect
+               end
+
+      buf.puts(<<-RUBY)
+validate_foreign_key(#{table_name.inspect}, #{target})
+      RUBY
+    end
+
     def append_change_check_constraints(table_name, delta, pre_buf, post_buf)
       (delta[:delete] || {}).each_value do |attrs|
         append_remove_check_constraint(table_name, attrs, pre_buf)
@@ -601,6 +620,10 @@ remove_foreign_key(#{table_name.inspect}, #{target})
 
       (delta[:add] || {}).each_value do |attrs|
         append_add_check_constraint(table_name, attrs, post_buf)
+      end
+
+      (delta[:validate] || {}).each_value do |attrs|
+        append_validate_check_constraint(table_name, attrs, post_buf)
       end
     end
 
@@ -625,6 +648,15 @@ add_check_constraint(#{table_name.inspect}, #{expression.inspect}, **#{attrs_opt
 
       buf.puts(<<-RUBY)
 remove_check_constraint(#{table_name.inspect}, #{expression.inspect}, **#{attrs_options.inspect})
+      RUBY
+    end
+
+    def append_validate_check_constraint(table_name, attrs, buf)
+      attrs_options = attrs[:options] || {}
+      name = attrs_options[:name]
+
+      buf.puts(<<-RUBY)
+validate_check_constraint(#{table_name.inspect}, name: #{name.inspect})
       RUBY
     end
 

--- a/lib/ridgepole/diff.rb
+++ b/lib/ridgepole/diff.rb
@@ -525,12 +525,17 @@ module Ridgepole
 
         if from_attrs
           if from_attrs != to_attrs && !ignorable_validate_diff?(from_attrs, to_attrs)
-            foreign_keys_delta[:add] ||= {}
-            foreign_keys_delta[:add][foreign_key_name_or_tables] = to_attrs
+            if validate_only_diff?(from_attrs, to_attrs)
+              foreign_keys_delta[:validate] ||= {}
+              foreign_keys_delta[:validate][foreign_key_name_or_tables] = to_attrs
+            else
+              foreign_keys_delta[:add] ||= {}
+              foreign_keys_delta[:add][foreign_key_name_or_tables] = to_attrs
 
-            unless options[:merge]
-              foreign_keys_delta[:delete] ||= {}
-              foreign_keys_delta[:delete][foreign_key_name_or_tables] = from_attrs
+              unless options[:merge]
+                foreign_keys_delta[:delete] ||= {}
+                foreign_keys_delta[:delete][foreign_key_name_or_tables] = from_attrs
+              end
             end
           end
         else
@@ -561,11 +566,16 @@ module Ridgepole
           from_normalized = normalize_check_constraint(from_attrs)
           to_normalized = normalize_check_constraint(to_attrs)
           if from_normalized != to_normalized && !ignorable_validate_diff?(from_normalized, to_normalized)
-            check_constraints_delta[:add] ||= {}
-            check_constraints_delta[:add][name] = to_attrs
+            if validate_only_diff?(from_normalized, to_normalized)
+              check_constraints_delta[:validate] ||= {}
+              check_constraints_delta[:validate][name] = to_attrs
+            else
+              check_constraints_delta[:add] ||= {}
+              check_constraints_delta[:add][name] = to_attrs
 
-            check_constraints_delta[:delete] ||= {}
-            check_constraints_delta[:delete][name] = from_attrs
+              check_constraints_delta[:delete] ||= {}
+              check_constraints_delta[:delete][name] = from_attrs
+            end
           end
         else
           check_constraints_delta[:add] ||= {}
@@ -601,6 +611,19 @@ module Ridgepole
       return false unless to_options[:validate] == false && !from_options.key?(:validate)
 
       from_attrs == to_attrs.merge(options: to_options.except(:validate))
+    end
+
+    # Reverse of ignorable_validate_diff?: DB has a NOT VALID constraint (validate: false)
+    # and the DSL implies validated (:validate missing or true). Emit VALIDATE CONSTRAINT
+    # instead of DROP + re-ADD so the full-table scan runs under SHARE UPDATE EXCLUSIVE
+    # (concurrent DML allowed) rather than ACCESS EXCLUSIVE lock.
+    def validate_only_diff?(from_attrs, to_attrs)
+      from_options = from_attrs[:options] || {}
+      to_options = to_attrs[:options] || {}
+      return false unless from_options[:validate] == false && to_options[:validate] != false
+
+      from_attrs.merge(options: from_options.except(:validate)) ==
+        to_attrs.merge(options: to_options.except(:validate))
     end
 
     def scan_exclusion_constraints_change(from, to, table_delta)

--- a/spec/postgresql/diff/diff_spec.rb
+++ b/spec/postgresql/diff/diff_spec.rb
@@ -380,6 +380,120 @@ describe 'Ridgepole::Client.diff' do
         expect(delta.script).to be_empty
       end
     end
+
+    context 'when foreign key exists with validate: false and DSL implies validated' do
+      let(:actual_dsl) do
+        <<-RUBY
+          create_table "users", force: :cascade do |t|
+            t.string "name", null: false
+          end
+
+          create_table "entries", force: :cascade do |t|
+            t.bigint "user_id", null: false
+          end
+
+          add_foreign_key "entries", "users", validate: false
+        RUBY
+      end
+
+      let(:expected_dsl) do
+        <<-RUBY
+          create_table "users", force: :cascade do |t|
+            t.string "name", null: false
+          end
+
+          create_table "entries", force: :cascade do |t|
+            t.bigint "user_id", null: false
+          end
+
+          add_foreign_key "entries", "users"
+        RUBY
+      end
+
+      it 'validates the foreign key instead of DROP + re-ADD' do
+        delta = subject.diff(actual_dsl, expected_dsl)
+        expect(delta).to be_differ
+        expect(delta.script).to match_ruby(<<-RUBY)
+          validate_foreign_key("entries", "users")
+        RUBY
+      end
+    end
+
+    context 'when foreign key exists with validate: false and DSL specifies validate: true' do
+      let(:actual_dsl) do
+        <<-RUBY
+          create_table "users", force: :cascade do |t|
+            t.string "name", null: false
+          end
+
+          create_table "entries", force: :cascade do |t|
+            t.bigint "user_id", null: false
+          end
+
+          add_foreign_key "entries", "users", validate: false
+        RUBY
+      end
+
+      let(:expected_dsl) do
+        <<-RUBY
+          create_table "users", force: :cascade do |t|
+            t.string "name", null: false
+          end
+
+          create_table "entries", force: :cascade do |t|
+            t.bigint "user_id", null: false
+          end
+
+          add_foreign_key "entries", "users", validate: true
+        RUBY
+      end
+
+      it 'validates the foreign key instead of DROP + re-ADD' do
+        delta = subject.diff(actual_dsl, expected_dsl)
+        expect(delta).to be_differ
+        expect(delta.script).to match_ruby(<<-RUBY)
+          validate_foreign_key("entries", "users")
+        RUBY
+      end
+    end
+
+    context 'when foreign key exists with validate: false and a name, and DSL implies validated' do
+      let(:actual_dsl) do
+        <<-RUBY
+          create_table "users", force: :cascade do |t|
+            t.string "name", null: false
+          end
+
+          create_table "entries", force: :cascade do |t|
+            t.bigint "user_id", null: false
+          end
+
+          add_foreign_key "entries", "users", name: "fk_entries_users", validate: false
+        RUBY
+      end
+
+      let(:expected_dsl) do
+        <<-RUBY
+          create_table "users", force: :cascade do |t|
+            t.string "name", null: false
+          end
+
+          create_table "entries", force: :cascade do |t|
+            t.bigint "user_id", null: false
+          end
+
+          add_foreign_key "entries", "users", name: "fk_entries_users"
+        RUBY
+      end
+
+      it 'validates the foreign key by name' do
+        delta = subject.diff(actual_dsl, expected_dsl)
+        expect(delta).to be_differ
+        expect(delta.script).to match_ruby(<<-RUBY)
+          validate_foreign_key("entries", name: "fk_entries_users")
+        RUBY
+      end
+    end
   end
 
   context 'when add check constraint with validate: false' do
@@ -435,6 +549,62 @@ describe 'Ridgepole::Client.diff' do
         delta = subject.diff(actual_dsl, expected_dsl)
         expect(delta).to_not be_differ
         expect(delta.script).to be_empty
+      end
+    end
+
+    context 'when check constraint exists with validate: false and DSL implies validated' do
+      let(:actual_dsl) do
+        <<-RUBY
+          create_table "products", force: :cascade do |t|
+            t.integer "price", null: false
+            t.check_constraint "price > 0", name: "products_price_check", validate: false
+          end
+        RUBY
+      end
+
+      let(:expected_dsl) do
+        <<-RUBY
+          create_table "products", force: :cascade do |t|
+            t.integer "price", null: false
+            t.check_constraint "price > 0", name: "products_price_check"
+          end
+        RUBY
+      end
+
+      it 'validates the check constraint instead of DROP + re-ADD' do
+        delta = subject.diff(actual_dsl, expected_dsl)
+        expect(delta).to be_differ
+        expect(delta.script).to match_ruby(<<-RUBY)
+          validate_check_constraint("products", name: "products_price_check")
+        RUBY
+      end
+    end
+
+    context 'when check constraint exists with validate: false and DSL specifies validate: true' do
+      let(:actual_dsl) do
+        <<-RUBY
+          create_table "products", force: :cascade do |t|
+            t.integer "price", null: false
+            t.check_constraint "price > 0", name: "products_price_check", validate: false
+          end
+        RUBY
+      end
+
+      let(:expected_dsl) do
+        <<-RUBY
+          create_table "products", force: :cascade do |t|
+            t.integer "price", null: false
+            t.check_constraint "price > 0", name: "products_price_check", validate: true
+          end
+        RUBY
+      end
+
+      it 'validates the check constraint instead of DROP + re-ADD' do
+        delta = subject.diff(actual_dsl, expected_dsl)
+        expect(delta).to be_differ
+        expect(delta.script).to match_ruby(<<-RUBY)
+          validate_check_constraint("products", name: "products_price_check")
+        RUBY
       end
     end
   end

--- a/spec/postgresql/fk/migrate_change_fk_spec.rb
+++ b/spec/postgresql/fk/migrate_change_fk_spec.rb
@@ -57,7 +57,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
     }
   end
 
-  context 'when change fk from validate: false to validated' do
+  context 'when change fk from validate: false to validated', condition: '>= 7.1.0' do
     let(:actual_dsl) do
       erbh(<<-ERB)
         create_table "parent", force: :cascade do |t|

--- a/spec/postgresql/fk/migrate_change_fk_spec.rb
+++ b/spec/postgresql/fk/migrate_change_fk_spec.rb
@@ -57,6 +57,65 @@ describe 'Ridgepole::Client#diff -> migrate' do
     }
   end
 
+  context 'when change fk from validate: false to validated' do
+    let(:actual_dsl) do
+      erbh(<<-ERB)
+        create_table "parent", force: :cascade do |t|
+        end
+
+        create_table "child", force: :cascade do |t|
+          t.integer "parent_id"
+          t.index ["parent_id"], name: "par_id"
+        end
+
+        add_foreign_key "child", "parent", validate: false
+      ERB
+    end
+
+    let(:sorted_actual_dsl) do
+      erbh(<<-ERB)
+        create_table "child", force: :cascade do |t|
+          t.integer "parent_id"
+          t.index ["parent_id"], name: "par_id"
+        end
+
+        create_table "parent", force: :cascade do |t|
+        end
+
+        add_foreign_key "child", "parent", validate: false
+      ERB
+    end
+
+    let(:expected_dsl) do
+      erbh(<<-ERB)
+        create_table "child", force: :cascade do |t|
+          t.integer "parent_id"
+          t.index ["parent_id"], name: "par_id"
+        end
+
+        create_table "parent", force: :cascade do |t|
+        end
+
+        add_foreign_key "child", "parent"
+      ERB
+    end
+
+    before { subject.diff(actual_dsl).migrate }
+
+    subject { client }
+
+    it {
+      delta = subject.diff(expected_dsl)
+      expect(delta.differ?).to be_truthy
+      expect(delta.script).to match_ruby(<<-RUBY)
+        validate_foreign_key("child", "parent")
+      RUBY
+      expect(subject.dump).to match_fuzzy sorted_actual_dsl
+      delta.migrate
+      expect(subject.dump).to match_ruby expected_dsl
+    }
+  end
+
   context 'when change fk without name' do
     let(:actual_dsl) do
       erbh(<<-ERB)

--- a/spec/postgresql/migrate/migrate_change_check_constraint_spec.rb
+++ b/spec/postgresql/migrate/migrate_change_check_constraint_spec.rb
@@ -63,6 +63,52 @@ describe 'Ridgepole::Client#diff -> migrate' do
     }
   end
 
+  context 'when change check constraint from validate: false to validated' do
+    let(:base_dsl) do
+      erbh(<<-ERB)
+        create_table "clubs", force: :cascade do |t|
+          t.bigint "value", null: false
+        end
+      ERB
+    end
+
+    let(:actual_dsl) do
+      erbh(<<-ERB)
+        create_table "clubs", force: :cascade do |t|
+          t.bigint "value", null: false
+          t.check_constraint "value > 0", name: "value_check", validate: false
+        end
+      ERB
+    end
+
+    let(:expected_dsl) do
+      erbh(<<-ERB)
+        create_table "clubs", force: :cascade do |t|
+          t.bigint "value", null: false
+          t.check_constraint "value > 0", name: "value_check"
+        end
+      ERB
+    end
+
+    before do
+      # Two-step setup so the check constraint is added via ALTER TABLE
+      # (PostgreSQL ignores NOT VALID on inline CREATE TABLE constraints).
+      subject.diff(base_dsl).migrate
+      subject.diff(actual_dsl).migrate
+    end
+    subject { client }
+
+    it {
+      delta = subject.diff(expected_dsl)
+      expect(delta.differ?).to be_truthy
+      expect(delta.script).to match_ruby(<<-RUBY)
+        validate_check_constraint("clubs", name: "value_check")
+      RUBY
+      delta.migrate
+      expect(subject.dump).to match_ruby expected_dsl
+    }
+  end
+
   context 'when do not change check constraint (but quoted)' do
     let(:actual_dsl) do
       erbh(<<-ERB)

--- a/spec/postgresql/migrate/migrate_change_check_constraint_spec.rb
+++ b/spec/postgresql/migrate/migrate_change_check_constraint_spec.rb
@@ -63,7 +63,7 @@ describe 'Ridgepole::Client#diff -> migrate' do
     }
   end
 
-  context 'when change check constraint from validate: false to validated' do
+  context 'when change check constraint from validate: false to validated', condition: '>= 7.1.0' do
     let(:base_dsl) do
       erbh(<<-ERB)
         create_table "clubs", force: :cascade do |t|


### PR DESCRIPTION
## Summary

Handles the reverse of #716: when the DB dump has `validate: false` and the DSL implies a validated constraint (`:validate` missing or `true`), emit `validate_foreign_key` / `validate_check_constraint` instead of DROP + re-ADD.

DROP + re-ADD holds ACCESS EXCLUSIVE across the full-table scan, blocking all reads and writes. `VALIDATE CONSTRAINT` scans under SHARE UPDATE EXCLUSIVE, allowing concurrent DML — which is the whole reason `validate: false` (NOT VALID) exists in the first place.

Without this, running the two-phase NOT VALID + VALIDATE workflow through ridgepole was very cumbersome. You *can* work around it by marking the constraint `ignore: true` and running `ALTER TABLE ... VALIDATE CONSTRAINT` via a block-conditioned `execute`, but it's fiddly. With this change, the workflow lives entirely in the Schemafile: apply `validate: false` first, then drop `validate: false` to validate.

Covers foreign keys and check constraints.

## Note on base branch

The logical base of this PR is **#716** (commit ca2350f), not `main`. Ideally this would be stacked on top of that PR, but I don't have push access to `ridgepole/ridgepole` to open the intermediate branch there. Please review #716 first; once it lands on `main`, this PR's diff will collapse to just the reverse-direction change.