### PR TITLE
Use mirror.gcr.io instead of Docker Hub

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,19 +1,19 @@
 services:
   mysql57:
-    image: "mysql:5.7"
+    image: "public.ecr.aws/docker/library/mysql:5.7"
     platform: linux/amd64
     ports:
       - "13316:3306"
     environment:
       MYSQL_ROOT_PASSWORD: password
   mysql80:
-    image: "mysql:8.0"
+    image: "public.ecr.aws/docker/library/mysql:8.0"
     ports:
       - "13318:3306"
     environment:
       MYSQL_ROOT_PASSWORD: password
   postgres:
-    image: "postgres:14"
+    image: "public.ecr.aws/docker/library/postgres:14"
     ports:
       - "15442:5432"
     environment:

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,19 +1,19 @@
 services:
   mysql57:
-    image: "public.ecr.aws/docker/library/mysql:5.7"
+    image: "mirror.gcr.io/library/mysql:5.7"
     platform: linux/amd64
     ports:
       - "13316:3306"
     environment:
       MYSQL_ROOT_PASSWORD: password
   mysql80:
-    image: "public.ecr.aws/docker/library/mysql:8.0"
+    image: "mirror.gcr.io/library/mysql:8.0"
     ports:
       - "13318:3306"
     environment:
       MYSQL_ROOT_PASSWORD: password
   postgres:
-    image: "public.ecr.aws/docker/library/postgres:14"
+    image: "mirror.gcr.io/library/postgres:14"
     ports:
       - "15442:5432"
     environment:


### PR DESCRIPTION
## What

`compose.yaml` の MySQL / PostgreSQL 公式イメージを Docker Hub から Google の Docker Hub キャッシュ (`mirror.gcr.io/library/*`) 経由で pull するように変更します。

## Why

Docker Hub のレートリミット回避のため。`mirror.gcr.io` は Docker Hub の人気イメージのプルスルーキャッシュで、キャッシュ HIT した分は Docker Hub のレートリミットにカウントされません。キャッシュミス時は Docker Hub に自動フォールバックします。イメージ・タグは Docker 公式イメージと同一なので挙動は変わりません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)