### PR TITLE
Bump version to 3.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 3.2
 
+### 3.2.3 (2026/08/01)
+
+- Emit `validate_constraint` when DB is NOT VALID and DSL implies validated. [pull#718](https://github.com/ridgepole/ridgepole/pull/718)
+- Ignore `validate: false` diff when existing constraint lacks `:validate`. [pull#716](https://github.com/ridgepole/ridgepole/pull/716)
+
 ### 3.2.2 (2026/06/14)
 
 - Fix constraint removal order when dropping columns. [pull#705](https://github.com/ridgepole/ridgepole/pull/705)

--- a/lib/ridgepole/version.rb
+++ b/lib/ridgepole/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Ridgepole
-  VERSION = '3.2.2'
+  VERSION = '3.2.3'
 end


### PR DESCRIPTION
## Changelog

### 3.2.3 (2026/08/01)

- Emit `validate_constraint` when DB is NOT VALID and DSL implies validated. [pull#718](https://github.com/ridgepole/ridgepole/pull/718)
- Ignore `validate: false` diff when existing constraint lacks `:validate`. [pull#716](https://github.com/ridgepole/ridgepole/pull/716)

🤖 Generated with [Claude Code](https://claude.com/claude-code)