### PR TITLE
Remove myschema link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ It defines DB schema using [Rails DSL](http://guides.rubyonrails.org/migrations.
 > Also developing similar declarative schema tools — single Go binary, plain SQL as the schema definition:
 >
 > * [pistachio](https://github.com/winebarrel/pistachio): for PostgreSQL
-> * [myschema](https://github.com/winebarrel/myschema): for MySQL
 
 > [!warning]
 > The order of columns when exporting has changed in Rails 8.1. https://github.com/rails/rails/pull/53281


### PR DESCRIPTION
Removed myschema link for MySQL from README.

<!--
Thank you for your pull request.
It would be helpful if you could clarify the problem by creating an issue first.
-->
