### PR TITLE
Add MySQL functional index tests and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,26 @@ create_table "users", force: :cascade do |t|
 end
 ```
 
+## Functional Index (MySQL)
+
+MySQL 8.0.13 or later supports functional key parts, also known as expression
+indexes. MySQL normalizes these expressions when storing them, and Ridgepole
+compares the normalized expression with the one in your Schemafile. To avoid
+repeated diffs, use the expression produced by `ridgepole --export` in your
+Schemafile.
+
+```ruby
+create_table "users", force: :cascade do |t|
+  t.datetime "deleted_at"
+  t.string   "email", null: false
+  t.string   "name", null: false
+
+  t.index "(lower(`name`))", name: "index_users_on_lower_name"
+  t.index "(case when (`deleted_at` is null) then `email` else NULL end)",
+          name: "index_users_on_active_email", unique: true
+end
+```
+
 ## Execute
 ```ruby
 create_table "authors", force: :cascade do |t|

--- a/spec/mysql/migrate/migrate_add_expression_index_spec.rb
+++ b/spec/mysql/migrate/migrate_add_expression_index_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+describe 'Ridgepole::Client#diff -> migrate', condition: [[:mysql80]] do
+  subject { client }
+
+  context 'when add_index contains expression' do
+    let(:actual_dsl) { '' }
+    let(:expected_dsl) { erbh(<<-ERB) }
+      create_table "users", force: :cascade do |t|
+        t.string "name", null: false
+        t.index "(lower(`name`))", name: "index_users_on_lower_name"
+      end
+    ERB
+
+    specify do
+      delta = subject.diff(expected_dsl)
+      expect(delta).to be_differ
+      expect(subject.dump).to match_fuzzy(actual_dsl)
+      delta.migrate
+      expect(subject.dump).to match_fuzzy(expected_dsl)
+    end
+  end
+
+  context 'when add_index contains expression that behaves like a partial index' do
+    let(:actual_dsl) { '' }
+    let(:expected_dsl) { erbh(<<-ERB) }
+      create_table "users", force: :cascade do |t|
+        t.datetime "deleted_at"
+        t.string "email", null: false
+        t.index "(case when (`deleted_at` is null) then `email` else NULL end)", name: "index_users_on_active_email", unique: true
+      end
+    ERB
+
+    specify do
+      delta = subject.diff(expected_dsl)
+      expect(delta).to be_differ
+      expect(subject.dump).to match_fuzzy(actual_dsl)
+      delta.migrate
+      expect(subject.dump).to match_fuzzy(expected_dsl)
+    end
+  end
+end

--- a/spec/mysql/migrate/migrate_add_expression_index_spec.rb
+++ b/spec/mysql/migrate/migrate_add_expression_index_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe 'Ridgepole::Client#diff -> migrate', condition: [[:mysql80]] do
+describe 'Ridgepole::Client#diff -> migrate', condition: :mysql80 do
   subject { client }
 
   context 'when add_index contains expression' do


### PR DESCRIPTION
## Summary

- Add MySQL 8.0 integration tests for functional indexes
- Cover a basic expression and a `CASE WHEN` expression that behaves like a partial unique index
- Document the minimum MySQL version, Schemafile syntax, and expression normalization behavior