### PR TITLE
Add rerun workflow to let anyone re-run failed CI

### DIFF
--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -1,0 +1,23 @@
+name: rerun
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  actions: write
+  pull-requests: read
+
+jobs:
+  rerun:
+    if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/rerun') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Re-run failed jobs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.issue.number }}
+        run: |
+          head_sha=$(gh api "/repos/${REPO}/pulls/${PR}" --jq '.head.sha')
+          run_id=$(gh api "/repos/${REPO}/actions/workflows/test.yml/runs?head_sha=${head_sha}&per_page=1" --jq '.workflow_runs[0].id')
+          gh api -X POST "/repos/${REPO}/actions/runs/${run_id}/rerun-failed-jobs"


### PR DESCRIPTION
## What

`/rerun` とPRにコメントすると、そのPRの `test.yml` の**失敗ジョブだけ**を再実行するワークフローを追加します。

## Why

GitHub UI の「Re-run jobs」ボタンは write 権限がある人にしか表示されず、フォークPRの作者はブラウザから再実行できません。flakyなテストが落ちたときに、だれでも（フォークPRの作者含め）再実行できるようにします。

## How

- `issue_comment` トリガー（ベースリポジトリ側の権限で動くのでフォークPRでも再実行可能）
- 対象PRの head SHA から最新の `test.yml` run を特定し、`rerun-failed-jobs` API を叩く
- 権限は `actions: write` と `pull-requests: read` のみ

## Note

`issue_comment` トリガーのワークフローは、main にマージされて初めて有効になります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)