### PR TITLE
Install Codecov CLI from PyPI to avoid keybase.io failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,6 +95,10 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           flags: ${{ matrix.ruby }},${{ matrix.gemfile }},${{ matrix.env }}
+          # NOTE: Install the CLI from PyPI. The default binary download verifies its
+          # GPG signature with a public key fetched from keybase.io, which hangs and
+          # then fails the job when keybase.io is unavailable.
+          use_pypi: true
       - name: Upload test results to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
@@ -103,6 +107,7 @@ jobs:
           fail_ci_if_error: true
           flags: ${{ matrix.ruby }},${{ matrix.gemfile }},${{ matrix.env }}
           files: ./junit_format/rspec_xml
+          use_pypi: true
       # NOTE: This check isn't very useful and slows down processing, so I'll comment it out.
       # - name: Build and install gem
       #   run: |


### PR DESCRIPTION
The codecov-action wrapper downloads the CLI binary and verifies its GPG
signature using a public key fetched from keybase.io. When keybase.io is
unavailable the key fetch hangs for minutes and the wrapper then exits
with "Could not verify signature", failing the job even though the tests
passed.

Setting use_pypi installs the CLI with pip from PyPI instead, which skips
the keybase.io lookup entirely.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011671zh4JPc1paqZMzL9ADP