### PR TITLE
Add --pg-change-table-comment option to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Usage: ridgepole [options]
         --drop-table-only
         --mysql-change-table-options
         --mysql-change-table-comment
+        --pg-change-table-comment
         --check-relation-type DEF_PK
         --ignore-table-comment
         --skip-column-comment-change


### PR DESCRIPTION
## Summary

* This pull request adds missing `--pg-change-table-comment` to the Help section in README.md so it matches the actual `ridgepole -h` output.
* The option was added in https://github.com/ridgepole/ridgepole/pull/587, but the README Help section was not updated at that time.

## Changes

* `README.md`: add `--pg-change-table-comment` to the Help block