### PR TITLE
Fix inverted "No change" log in `--diff --with-apply`

### DIFF
--- a/bin/ridgepole
+++ b/bin/ridgepole
@@ -290,7 +290,7 @@ begin
 
       differ, _out = delta.migrate if differ
 
-      logger.info('No change') if differ
+      logger.info('No change') unless differ
     elsif delta.differ?
       differ = noop_migrate(delta, options)
       exit_code = 1 if differ


### PR DESCRIPTION
Thank you for developing and maintaining ridgepole!

While reading `bin/ridgepole`, I noticed that the `--diff --with-apply` path logs `"No change"` incorrectly.

## Summary

- In the `--diff --with-apply` path, `"No change"` was logged when migration actually happened, because the condition used `if differ` instead of `unless differ`.
- Fixed it to use `unless differ`, consistent with the `--apply` path.

## Changes

- `bin/ridgepole`: change `logger.info('No change') if differ` to `unless differ` in the `--diff --with-apply` branch

## Before/After

```bash
$ cat file1.schema
create_table "articles", force: :cascade do |t|
  t.string   "title"
  t.text     "text"
  t.datetime "created_at"
  t.datetime "updated_at"
end
```

### Before

```bash
$ bundle exec ridgepole --diff file1.schema file1.schema --with-apply

```

### After

```bash
$ bundle exec ridgepole --diff file1.schema file1.schema --with-apply
No change
```
