### PR TITLE
Add CLI specs for `--diff ... --with-apply`

### DIFF
--- a/spec/mysql/cli/ridgepole_spec.rb
+++ b/spec/mysql/cli/ridgepole_spec.rb
@@ -293,6 +293,18 @@ describe 'ridgepole' do
       MSG
     end
 
+    specify 'with-apply' do
+      out, status = run_cli(args: ['-c', conf, '-d', conf, conf, '--with-apply'])
+
+      expect(status.success?).to be_truthy
+      expect(out).to match_fuzzy <<-MSG
+        Ridgepole::Client#initialize([#{conn_spec_str('ridgepole_test')}, #{{ dry_run: false, debug: false, color: false }}])
+        Ridgepole::Client.diff([#{conn_spec_str('ridgepole_test')}, #{conn_spec_str('ridgepole_test')}, #{{ dry_run: false, debug: false, color: false }}])
+        Ridgepole::Delta#differ?
+        No change
+      MSG
+    end
+
     context 'when differ true' do
       let(:differ) { true }
 
@@ -314,6 +326,18 @@ describe 'ridgepole' do
           Ridgepole::Delta#migrate
           # create_table :table do
           # end
+        MSG
+      end
+
+      specify 'with-apply' do
+        out, status = run_cli(args: ['-c', conf, '-d', conf, conf, '--with-apply'])
+
+        expect(status.success?).to be_truthy
+        expect(out).to match_fuzzy <<-MSG
+          Ridgepole::Client#initialize([#{conn_spec_str('ridgepole_test')}, #{{ dry_run: false, debug: false, color: false }}])
+          Ridgepole::Client.diff([#{conn_spec_str('ridgepole_test')}, #{conn_spec_str('ridgepole_test')}, #{{ dry_run: false, debug: false, color: false }}])
+          Ridgepole::Delta#differ?
+          Ridgepole::Delta#migrate
         MSG
       end
     end


### PR DESCRIPTION
The inverted `No change` condition fixed in #730 went unnoticed since b84d10c (2014) because no spec exercised the CLI output of `--diff DSL1 DSL2 --with-apply`. This fills that gap.

Two specs added to `spec/mysql/cli/ridgepole_spec.rb`:

- **no diff** (directly under `when diff`): `migrate` is not called and `No change` is printed
- **diff present** (under `when differ true`): `migrate` is called and `No change` is not printed

`match_fuzzy` is a whitespace-normalized exact match, so a stray `No change` is caught too.

## Verification

Reverting `unless differ` back to `if differ` in `bin/ridgepole` makes both specs fail (one for the missing `No change`, the other for the extra `+No change`). Both pass with the fix in place.

Like the existing `-a` specs, these run against the mock in `spec/cli_helper.rb` (`let(:differ)`), so they don't touch a database. There is no CLI spec on the PostgreSQL side, so this is mysql only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SR7PXAFr4xLcGoJtmUEbS6
