### PR TITLE
Bump version to 3.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 3.2
 
+### 3.2.4 (2026/08/08)
+
+- Fix inverted "No change" log in `--diff --with-apply`. [pull#730](https://github.com/ridgepole/ridgepole/pull/730)
+
 ### 3.2.3 (2026/08/01)
 
 - Emit `validate_constraint` when DB is NOT VALID and DSL implies validated. [pull#718](https://github.com/ridgepole/ridgepole/pull/718)

--- a/lib/ridgepole/version.rb
+++ b/lib/ridgepole/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Ridgepole
-  VERSION = '3.2.3'
+  VERSION = '3.2.4'
 end


### PR DESCRIPTION
## Summary

Release preparation for v3.2.4.

- Add 3.2.4 entry to CHANGELOG.md
- Bump `Ridgepole::VERSION` to `3.2.4`

## Changes since v3.2.3

- Fix inverted "No change" log in `--diff --with-apply`. #730

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011G2gUAUjQP1EfoHfAzo6Rx